### PR TITLE
CI: Use correct key name in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - set -e
   # Build docs.
   - |
-    if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD_DOCS ]]; then
+    if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_HAPPI" && $BUILD_DOCS ]]; then
       pushd docs
       sphinx-autogen -o source/generated source/*.rst 
       make html


### PR DESCRIPTION
Newer versions of `doctr` change the key name. This needs to be updated in Travis.
