### PR TITLE
FIX: Edge cases in templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ install:
 script:
   - coverage run run_tests.py
   - coverage report -m
+  - flake8 happi
   - set -e
   # Build docs.
   - |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 sphinx
 sphinx_rtd_theme
 psdm_qs_cli
+flake8

--- a/happi/containers.py
+++ b/happi/containers.py
@@ -32,15 +32,6 @@ class BeamControl(Device):
     system.default = 'beam control'
 
 
-class BeamSteering(BeamControl):
-    """
-    Parent class for devices that direct the beam from one line to another.
-    """
-    destinations = EntryInfo('Mapping from steering states PV to ' +
-                             'destination beamlines',
-                             optional=False, enforce=dict)
-
-
 # Basic classes that inherit from above
 class GateValve(Vacuum):
     """
@@ -192,7 +183,7 @@ class Stopper(Device):
     device_class = 'pcdsdevices.device_types.Stopper'
 
 
-class OffsetMirror(BeamSteering):
+class OffsetMirror(BeamControl):
     """
     A device that steers beam in the x direction by changing a pitch motor.
     These are used for beam delivery and alignment. These have additional
@@ -244,7 +235,7 @@ class PulsePicker(BeamControl):
     device_class.default = 'pcdsdevices.device_types.PulsePicker'
 
 
-class LODCM(BeamSteering):
+class LODCM(BeamControl):
     """
     This LODCM class doesn't refer to the full LODCM, but rather one of the two
     crystals. This makes 4 LODCM objects in total, 2 for each LODCM. These have

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -12,7 +12,7 @@ from .utils import create_alias
 
 logger = logging.getLogger(__name__)
 
-cache= dict()
+cache = dict()
 
 
 def fill_template(template, device, enforce_type=False):

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -38,6 +38,9 @@ def fill_template(template, device, enforce_type=False):
         # Find which variable we used in the template, get the type and convert
         # our rendered template to agree with this
         info = meta.find_undeclared_variables(env.environment.parse(template))
+        # If no variables were substituted there is no type to enforce
+        if not info:
+            return filled
         # We select a type at random here. If we use two different variables
         # in the same template that disagree on type we could have an issue
         # but I decided that we will deal with that issue if it arises

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -15,6 +15,9 @@ def test_fill_template(device):
     template = '{{z}}'
     z = fill_template(template, device, enforce_type=True)
     assert isinstance(z, float)
+    # Check that we will convert a more complex template
+    template = '{{z*100}}'
+    assert z*100 == fill_template(template, device, enforce_type=True)
     # Check that we can handle non-jinja template
     template = "blah"
     assert template == fill_template(template, device, enforce_type=True)

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -15,6 +15,12 @@ def test_fill_template(device):
     template = '{{z}}'
     z = fill_template(template, device, enforce_type=True)
     assert isinstance(z, float)
+    # Check that we can handle non-jinja template
+    template = "blah"
+    assert template == fill_template(template, device, enforce_type=True)
+    # Check that we do not enforce a NoneType
+    template = "{{screen}}"
+    assert fill_template(template, device, enforce_type=True) is None
 
 
 def test_from_container():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Found these two edge cases while populating the happi database with XRT devices:
* If there was an optional keyword mentioned in kwargs we would try and convert it to a NoneType. This was annoying in the case:
```python
MyDevice.prefix_det = None
MyDevice.kwargs = {"name": "{{name}}", "prefix_det": "{{prefix_det}}"}
```
* The `fill_template` raised an error if we tried to enforce_type on a already filled_template i.e `kwargs = {'a': 'b'}`
* In an older version of `lightpath` you had to pass in `destinations` to each branching device. This is no longer the case. I deprecated the Container type that required this as a piece of `EntryInfo`
* Add `flake8` tests to Travis

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are added for edge cases
