### PR TITLE
ENH:Questionnaire Motor Guess

### DIFF
--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -29,7 +29,8 @@ def guess_motor_class(prefix):
     Returns
     -------
     device_class : str
-        Type of EpicsMotor. If not, we assume can use pcdsd
+        Type of EpicsMotor. If not, we assume
+        `pcdsdevices.epics_motor.PCDSMotorBase`
     """
     for _typ in motor_types:
         if _typ in prefix:

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -12,6 +12,31 @@ from ..errors import DatabaseError
 logger = logging.getLogger(__name__)
 
 
+# Declare our motor types
+motor_types = {'MMS': 'pcdsdevices.epics_motor.IMS',
+               'MMN': 'pcdsdevices.epics_motor.Newport',
+               'MZM': 'pcdsdevices.epics_motor.PMC100'}
+
+
+def guess_motor_class(prefix):
+    """
+    Guess the corresponding pcdsdevices.epics_motor class based on prefix
+
+    Parameters
+    ----------
+    prefix : str
+
+    Returns
+    -------
+    device_class : str
+        Type of EpicsMotor. If not, we assume can use pcdsd
+    """
+    for _typ in motor_types:
+        if _typ in prefix:
+            return motor_types[_typ]
+    return 'pcdsdevices.epics_motor.PCDSMotorBase'
+
+
 class QSBackend(JSONBackend):
     """
     Questionniare Backend

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -63,7 +63,7 @@ class QSBackend(JSONBackend):
     proposal: str
         Proposal identifier i.e "LR32"
     """
-    device_translations = {'motors': 'pcdsdevices.epics_motor.EpicsMotor'}
+    device_translations = {'motors': guess_motor_class}
 
     def __init__(self, run_no, proposal, **kwargs):
         # Create our client and gather the raw information from the client
@@ -129,7 +129,7 @@ class QSBackend(JSONBackend):
                         post = {'name': dev_info.pop('name'),
                                 'prefix': dev_info['pvbase'],
                                 'beamline': beamline,
-                                'device_class': _class,
+                                'device_class': _class(dev_info['pvbase']),
                                 'type': 'Device',
                                 # TODO: We should not assume that we are using
                                 # the prefix as _id. Other backends do not make
@@ -145,9 +145,9 @@ class QSBackend(JSONBackend):
                                 raise Exception("Unable to create a device "
                                                 " without %s".format(key))
                     except Exception as exc:
-                        logger.warning("Unable to create a %s from "
-                                       "Questionnaire row %s",
-                                       _class, num)
+                        logger.warning("Unable to create an object from "
+                                       "Questionnaire table %s row %s",
+                                       field, num)
                     else:
                         self.db[post['_id']] = post
 

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -158,6 +158,7 @@ def test_qsbackend_with_client(mockqsbackend):
     assert all([d.device_class == 'pcdsdevices.epics_motor.IMS'
                 for d in c.all_devices])
 
+
 @requires_questionnaire
 def test_guess_motor_class():
     from happi.backends.qs_db import guess_motor_class

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -155,7 +155,8 @@ def test_qs_find(mockqsbackend):
 def test_qsbackend_with_client(mockqsbackend):
     c = Client(database=mockqsbackend)
     assert len(c.all_devices) == 6
-
+    assert all([d.device_class == 'pcdsdevices.epics_motor.IMS'
+                for d in c.all_devices])
 
 @requires_questionnaire
 def test_guess_motor_class():

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -155,3 +155,9 @@ def test_qs_find(mockqsbackend):
 def test_qsbackend_with_client(mockqsbackend):
     c = Client(database=mockqsbackend)
     assert len(c.all_devices) == 6
+
+
+@requires_questionnaire
+def test_guess_motor_class():
+    from happi.backends.qs_db import guess_motor_class
+    assert guess_motor_class('Tst:MMN:01') == 'pcdsdevices.epics_motor.Newport'


### PR DESCRIPTION
DO NOT MERGE UNTIL https://github.com/pcdshub/pcdsdevices/pull/167
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When loading motors from the Questionnaire, guess which type each is by looking at the prefix. I view this is a temporary fix until the QuestionnaireClient can tell us explicitly which class should be loaded.

**Question:** Should the default be `pcdsdevices.epics_motor.PCDSMotorBase` or `ophyd.EpicsMotor`? Not sure ... My only thought is that our base version will work on true MotorRecord motors, but the `EpicsMotor` won't work with our bastards.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this fix Newport and PMC100 motors will not load properly from the Questionnaire. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for both guessing the motor type, and that it works in situ.