### PR TITLE
MAINT: Check metadata on Device before using cache

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,3 +27,9 @@ there are still standards within the group we need to uphold.
    client_api.rst
    backends.rst
    containers.rst
+
+.. toctree::
+   :maxdepth: 0
+   :caption: Developer Documentation
+
+   releases.rst

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,0 +1,36 @@
+#############
+Release Notes
+#############
+
+v1.1.1 (2018-03-08)
+===================
+
+Enhancements
+------------
+- The ``QSBackend`` guesses which a type of motor based on the ``prefix``.
+  Currently this supports ``Newport``, ``IMS``, and ``PMC100`` motors. While there is
+  not an explicit dependency, this will require ``pcdsdevices >= 0.5.0`` to load
+  properly (#51)
+
+Bug Fixes
+---------
+- Templating is more robust when dealing with types. This includes a fatal case
+  where the default for an ``EntryInfo`` is ``None`` (#50)
+- A proper error message is returned if an entry in the table does not have the
+  requisite information to load (#53 )
+
+v1.1.0 (2018-02-13)
+===================
+Ownership of this repository has been transferred to
+`<https://github.com/pcdshub>`_
+
+Enhancements
+------------
+- Happi now has a cache so the repeated requests to load the same device do
+  not spawn multiple objects.
+
+Maintenance
+-----------
+- Cleaner logging messages
+- ``QSBackend`` was expanded to accommodate different keyword arguments
+  associated with different authentication methods.

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -2,6 +2,15 @@
 Release Notes
 #############
 
+Next Release
+============
+
+Maintenance
+-----------
+- In :meth:`.from_container`, the provided container is compared against
+  the cached version of the device to find discrepancies. This means that
+  modified container objects will always load a new Device. (#62)
+
 v1.1.1 (2018-03-08)
 ===================
 

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -100,7 +100,17 @@ def from_container(device, attach_md=True, use_cache=True):
     """
     # Return a cached version of the device if present and not forced
     if use_cache and device.prefix in cache:
-        return cache[device.prefix]
+        cached_device = cache[device.prefix]
+        # If the metadata has not been modified or we can't review it.
+        # Return the cached object
+        if not hasattr(cached_device, 'md') or cached_device.md == device:
+            logger.debug("Loading %s from cache ...", device.prefix)
+            return cached_device
+        # Otherwise reload
+        else:
+            logger.warning("Device %s has already been loaded, but the "
+                           "database information has been modified. "
+                           "Reloading ...", device.prefix)
 
     # Find the class and module of the container.
     if not device.device_class:

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -77,7 +77,10 @@ def from_container(device, attach_md=True, use_cache=True):
 
     By default, the instantiated object has the original container added on as
     ``.md``. This allows applications to utilize additional metadata
-    information that may not be included in the basic class constructor.
+    information that may not be included in the basic class constructor. On
+    later calls, the container you request is checked against this stored
+    metadata. If a discrepancy is found the object is **forced** to reload, not
+    retrieved from the cache.
 
     Parameters
     ----------
@@ -92,7 +95,9 @@ def from_container(device, attach_md=True, use_cache=True):
         return the same object. This prevents unnecessary EPICS connections
         from being initialized in the same process. If a new object is
         needed, set `use_cache` to False and a new object will be created,
-        overriding the current cached object
+        overriding the current cached object. An object with matching prefix
+        and differing metadata will always return a new instantiation of the
+        device.
 
     Returns
     -------

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -40,10 +40,20 @@ def test_from_container():
 def test_caching():
     # Create a datetime device
     d = TimeDevice(name='Test', prefix='Tst:This:2', beamline='TST',
-                   device_class='datetime.timedelta', args=list(), days=10,
+                   device_class='types.SimpleNamespace', args=list(), days=10,
                    kwargs={'days': '{{days}}', 'seconds': 30})
     td = from_container(d)
     assert d.prefix in cache
+    assert id(td) == id(from_container(d))
+    assert id(td) != id(from_container(d, use_cache=False))
+    # Modify md and check we see a reload
+    d.days = 12
+    assert id(td) != id(from_container(d, use_cache=True))
+    # Check with a device where metadata is unavailable
+    d = TimeDevice(name='Test', prefix='Tst:Delta:3', beamline='TST',
+                   device_class='datetime.timedelta', args=list(), days=10,
+                   kwargs={'days': '{{days}}', 'seconds': 30})
+    td = from_container(d)
     assert id(td) == id(from_container(d))
     assert id(td) != id(from_container(d, use_cache=False))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Prior to this `from_container` quietly grabbed devices from the cache if `use_cache` was True. This is confusing if you want to iterate on your container a few times before saving to the database.

```python
# Load device once
my_device.name = 'Unchanged Name'
my_device = from_container(my_container)
# Modify container
my_container.name = 'Changed Name'
# Load device again
my_device = from_container(my_container)
my_device.name == 'Unchanged Name'  # VERY CONFUSING
```
After #40 we can expect most of our objects to have the metadata they were loaded with attached as `md`. This PR adds a little check, if the `md` stored on the cached device is differing from incoming container, we force a reload, even if they share a prefix. This prevents the situation above. If the cached device does not have the `md` attached we just listen to whatever `use_cache` says.

Also, added some logging messages. I want to keep these as a low priority as I don't want users to be discouraged from using the cache for applications and loading 100 devices all from the cache with a `logger.INFO` message could get loud. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #60 without changing the default behavior of the function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added more nuanced testing of behavior.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated docstring with a more complete explanation.

