### PR TITLE
ENH: Threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -228,19 +228,28 @@ def load_device(device, pprint=False, threaded=False, **kwargs):
     # catch and store it so we can easily view the traceback
     # later without going to logs, e.t.c
     logger.debug("Loading device %s ...", device.name)
+    load_message = "Loading %s [%s] ... "
+    success = "\033[32mSUCCESS\033[0m!"
+    failed = "\033[31mFAILED\033[0m"
     if pprint:
-        print("Loading {} [{}]...".format(device.name,
-                                          device.device_class),
-              end=' ')
+        device_message = load_message % (device.name, device.device_class)
+        if not threaded:
+            print(device_message, end='')
     try:
         loaded = from_container(device, **kwargs)
-        logger.info("Loading %s [%s] ... \033[32mSUCCESS\033[0m!",
+        logger.info(load_message + success,
                     device.name, device.device_class)
         if pprint:
-            print("\033[32mSUCCESS\033[0m")
+            if threaded:
+                print(device_message + success)
+            else:
+                print(success)
     except Exception as exc:
         if pprint:
-            print("\033[31mFAILED\033[0m")
+            if threaded:
+                print(device_message + failed)
+            else:
+                print(failed)
         logger.exception('Error loading %s', device.name)
         loaded = exc
     return loaded

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -254,9 +254,27 @@ def load_devices(*devices, pprint=False, namespace=None, use_cache=True,
 
 def load_device(device, pprint=False, threaded=False, post_load=None,
                 **kwargs):
-    # Attempt to load our device. If this raises an exception
-    # catch and store it so we can easily view the traceback
-    # later without going to logs, e.t.c
+    """
+    Call :func:`.from_container ` and show success/fail
+
+    Parameters
+    ----------
+    device : happi.Device
+
+    pprint: bool, optional
+        Print results of device loads
+
+    threaded: bool, optional
+        Set this to True when calling inside a thread.
+
+    post_load : function, optional
+        Function of one argument to run on each device after instantiation.
+        This is your opportunity to check for good device health during the
+        threaded load.
+
+    kwargs:
+        Are passed to :func:`.from_container`
+    """
     logger.debug("Loading device %s ...", device.name)
 
     # We sync with the main thread's loop so that they work as expected later

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -161,12 +161,13 @@ def import_class(device_class):
 
     Parameters
     ----------
-    device_class : ``str``
-        The module path to find the class e.g. "pcdsdevices.device_types.IPM"
+    device_class : str
+        The module path to find the class e.g.
+        ``"pcdsdevices.device_types.IPM"``
 
     Returns
     -------
-    cls : ``type``
+    cls : type
         The class referred to by the input string.
     """
     mod, cls = device_class.rsplit('.', 1)
@@ -193,13 +194,13 @@ def load_devices(*devices, pprint=False, namespace=None, use_cache=True,
 
     Parameters
     ----------
-    args :
+    *devices :
         List of happi containers to load
 
     pprint: bool, optional
         Print results of device loads
 
-    namespace : obj, optional
+    namespace : object, optional
         Namespace to collect loaded devices in. By default this will be a
         ``types.SimpleNamespace``
 
@@ -208,11 +209,10 @@ def load_devices(*devices, pprint=False, namespace=None, use_cache=True,
         devices.
 
     threaded : bool, optional
-        Set to True to create each device in a background thread.
-        Note that this assumes that no two devices in the *devices input are
-        the same device. You are not guaranteed to load from the cache
-        correctly if you ask for the same device to be loaded twice in the same
-        threaded load.
+        Set to True to create each device in a background thread.  Note that
+        this assumes that no two devices provided are the same. You are not
+        guaranteed to load from the cache correctly if you ask for the same
+        device to be loaded twice in the same threaded load.
 
     post_load : function, optional
         Function of one argument to run on each device after instantiation.

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -70,7 +70,8 @@ def test_add_md():
 
 
 @pytest.mark.parametrize('threaded', [False, True])
-def test_load_devices(threaded):
+@pytest.mark.parametrize('wait', [False, True])
+def test_load_devices(threaded, wait):
     # Create a bunch of devices to load
     devs = [TimeDevice(name='Test 1', prefix='Tst1:This', beamline='TST',
                        device_class='datetime.timedelta', args=list(), days=10,
@@ -85,7 +86,7 @@ def test_load_devices(threaded):
                    device_class='non.existant')]
     # Load our devices
     space = load_devices(*devs, pprint=True, use_cache=False,
-                         threaded=threaded)
+                         threaded=threaded, wait=wait)
     # Check all our devices are there
     assert all([create_alias(dev.name) in space.__dict__ for dev in devs])
     # Devices were loading properly or exceptions were stored

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -70,8 +70,8 @@ def test_add_md():
 
 
 @pytest.mark.parametrize('threaded', [False, True])
-@pytest.mark.parametrize('wait', [False, True])
-def test_load_devices(threaded, wait):
+@pytest.mark.parametrize('post_load', [None, lambda x: None])
+def test_load_devices(threaded, post_load):
     # Create a bunch of devices to load
     devs = [TimeDevice(name='Test 1', prefix='Tst1:This', beamline='TST',
                        device_class='datetime.timedelta', args=list(), days=10,
@@ -86,7 +86,7 @@ def test_load_devices(threaded, wait):
                    device_class='non.existant')]
     # Load our devices
     space = load_devices(*devs, pprint=True, use_cache=False,
-                         threaded=threaded, wait=wait)
+                         threaded=threaded, post_load=post_load)
     # Check all our devices are there
     assert all([create_alias(dev.name) in space.__dict__ for dev in devs])
     # Devices were loading properly or exceptions were stored

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -1,3 +1,5 @@
+import pytest
+
 from happi import Device, EntryInfo, cache
 from happi.loader import fill_template, from_container, load_devices
 from happi.utils import create_alias
@@ -67,7 +69,8 @@ def test_add_md():
     assert obj.md.name == 'Test'
 
 
-def test_load_devices():
+@pytest.mark.parametrize('threaded', [False, True])
+def test_load_devices(threaded):
     # Create a bunch of devices to load
     devs = [TimeDevice(name='Test 1', prefix='Tst1:This', beamline='TST',
                        device_class='datetime.timedelta', args=list(), days=10,
@@ -81,7 +84,8 @@ def test_load_devices():
             Device(name='Bad', prefix='Not:Here', beamline='BAD',
                    device_class='non.existant')]
     # Load our devices
-    space = load_devices(*devs, pprint=True)
+    space = load_devices(*devs, pprint=True, use_cache=False,
+                         threaded=threaded)
     # Check all our devices are there
     assert all([create_alias(dev.name) in space.__dict__ for dev in devs])
     # Devices were loading properly or exceptions were stored


### PR DESCRIPTION
Closes #66 

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- `load_devices` has an option to create each device in a background thread
- `load_devices` has an option to call an arbitrary function on the loaded devices in the background thread, to be used to wait for connection, etc.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- This is needed before we transfer the camera load from `hutch-python` to `happi`
- This allows us to efficiently load devices that need PV gets to initialize that could time out
- This allows us to catch timeouts/disconnections early without sacrificing tons of time for applications like `lightpath`, but also give us flexibility to add checks in applications that need specific checks without thinking of all the possibilities in the `happi` module. It also helps stave off the "hidden" `ophyd` dependence by not assuming we only have `Device` and `Signal` objects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added testing
- Works for xpp

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- Expanded docstrings appropriately

<!--
## Screenshots (if appropriate):
-->
