### PR TITLE
API: break API to jump to new qs_cli interface

### DIFF
--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -58,21 +58,23 @@ class QSBackend(JSONBackend):
 
     Parameters
     ----------
-    run_no : int
-        Desired run number i.e 16
-
-    proposal: str
-        Proposal identifier i.e "LR32"
+    expname : str
+        The experiment name from the elog, e.g. xcslp1915
     """
     device_translations = {'motors': guess_motor_class}
 
-    def __init__(self, run_no, proposal, **kwargs):
+    def __init__(self, expname, **kwargs):
         # Create our client and gather the raw information from the client
         self.qs = QuestionnaireClient(**kwargs)
 
-        # Ensure that our user entered a valid run number and proposal
-        # identification
-        run_no = 'run{}'.format(run_no)
+        # Ensure that our user entered a valid expname
+        exp_dict = self.qs.getExpName2URAWIProposalIDs()
+        try:
+            proposal = exp_dict[expname]
+        except KeyError:
+            err = '{} is not a valid experiment name.'
+            raise ValueError(err.format(expname))
+        run_no = 'run{}'.format(expname[-2:])
         try:
             logger.debug("Requesting list of proposals in %s", run_no)
             prop_ids = self.qs.getProposalsListForRun(run_no)

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -141,11 +141,16 @@ def mockqsbackend():
                 'pcdssetup-motors-setup-6-pvbase': 'TST:USR:MMS:06',
                 'pcdssetup-motors-setup-6-stageidentity': 'IMS MD23'}
 
+        def getExpName2URAWIProposalIDs(self):
+            return {
+                'tstx53416': 'X534',
+                'tstlr3216': 'LR32'}
+
     with patch('happi.backends.qs_db.QuestionnaireClient') as qs_cli:
         # Replace QuestionnaireClient with our test version
         mock_qs = MockQuestionnaireClient(use_kerberos=False,
                                           user='user', pw='pw')
         qs_cli.return_value = mock_qs
         # Instantiate a fake device
-        backend = QSBackend(15, 'LR32')
+        backend = QSBackend('tstlr3216')
         return backend


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Murali added a method to the psdm_qs_cli to map elog experiment name to questionnaire proposal name.

This breaks the API of the qs backend, now we:
- input expname from the elog
- ask psdm_qs_cli what the proposal is
- figure out the run number via slicing

The previous API was:
- input proposal, run number

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are not guaranteed for the previous "slice the expname" schemes as in `hutch-python` to remain working. In fact, they break immediately for these "fake" questionnaire experiments that were added to do testing before run 17. It's probably better to trust the qs api and do no real processing from `get_expname` to talking to the questionnaire.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Adjusted the automated tests, and verified with calls like:
```
In [6]: backend = QSBackend('xpplr0416')

In [7]: backend.load()
Out[7]: 
{'XPP:USR:MMS:03': {'name': 'svhh',
  'prefix': 'XPP:USR:MMS:03',
  'beamline': 'XPP',
  'device_class': 'pcdsdevices.epics_motor.IMS',
  'type': 'Device',
  '_id': 'XPP:USR:MMS:03',
  'purpose': 'von Hamos h',
  'location': 'XPP goniometer'}}
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Tomorrow
<!--
## Screenshots (if appropriate):
-->
