### PR TITLE
Discussion: Explicit import of from_container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ script:
   - |
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_HAPPI" && $BUILD_DOCS ]]; then
       pushd docs
-      sphinx-autogen -o source/generated source/*.rst 
       make html
       popd
       # Publish docs.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = HappiDeck
 SOURCEDIR     = source

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosectionlabel'
              ]
 
+autosummary_generate = True
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/containers.rst
+++ b/docs/source/containers.rst
@@ -32,3 +32,11 @@ basis.
    happi.containers.PulsePicker
    happi.containers.LODCM
    happi.containers.MovableStand
+
+
+Loading Containers
+------------------
+
+.. autofunction:: happi.from_container
+
+.. autofunction:: happi.load_devices

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -88,3 +88,24 @@ These should have no default value. When entering information you will not
 neccesarily see a difference in between optional and mandatory
 :class:`.EntryInfo`, however the database client will reject the device if
 these fields don't have values associated with them. 
+
+
+Loading Devices
+^^^^^^^^^^^^^^^
+Part of happi's job is to contain the information necessary to load the Python
+representation of an object. This information is stored as a ``device_class``,
+``args`` and ``kwargs``. The former stores a string that indicates the Python
+class of the device, the other two indicate the information that is needed to
+instantiate it. With this information both :func:`.from_container` and
+:func:`.load_devices` will handle importing modules and instantiating your
+device. To keep track of the container the device that was instantiated has an
+attribute attached ``.md`` which will return the original container.
+
+Often information contained in the ``args`` or ``kwargs`` will be duplicated in
+other parts of the container. For instance most ``ophyd`` objects will want a
+``name`` and ``prefix`` on initialization. Instead of repeating that
+information you can just use a template and have the information automatically
+populated for you by the container itself. For instance, in the aforementioned
+example `device.args = ["{{prefix}}"]` would substitute the attribute listed as
+`Device.prefix` in as an argument. If the template contains the substituted
+attribute alone the type will also be converted.

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -5,11 +5,12 @@ Release Notes
 v1.1.2 (2018-08-30)
 ===================
 
-Maintenance
------------
+**Maintenance**
+
 - In :meth:`.from_container`, the provided container is compared against
   the cached version of the device to find discrepancies. This means that
   modified container objects will always load a new Device. (#62)
+
 - The ``QSBackend`` uses newer methods available in the ``psdm_qs_cli`` to
   determine the proposal from the experiment name. This is more robust against
   exotic experiment naming schemas than prior implementations (#68)
@@ -17,17 +18,18 @@ Maintenance
 v1.1.1 (2018-03-08)
 ===================
 
-Enhancements
-------------
+**Enhancements**
+
 - The ``QSBackend`` guesses which a type of motor based on the ``prefix``.
   Currently this supports ``Newport``, ``IMS``, and ``PMC100`` motors. While there is
   not an explicit dependency, this will require ``pcdsdevices >= 0.5.0`` to load
   properly (#51)
 
-Bug Fixes
----------
+**Bug Fixes**
+
 - Templating is more robust when dealing with types. This includes a fatal case
   where the default for an ``EntryInfo`` is ``None`` (#50)
+
 - A proper error message is returned if an entry in the table does not have the
   requisite information to load (#53 )
 
@@ -36,13 +38,14 @@ v1.1.0 (2018-02-13)
 Ownership of this repository has been transferred to
 `<https://github.com/pcdshub>`_
 
-Enhancements
-------------
+**Enhancements**
+
 - Happi now has a cache so the repeated requests to load the same device do
   not spawn multiple objects.
 
-Maintenance
------------
+**Maintenance**
+
 - Cleaner logging messages
-- ``QSBackend`` was expanded to accommodate different keyword arguments
-  associated with different authentication methods.
+
+  - ``QSBackend`` was expanded to accommodate different keyword arguments
+     associated with different authentication methods.

--- a/happi/__init__.py
+++ b/happi/__init__.py
@@ -1,7 +1,9 @@
+__all__ = ['Device', 'EntryInfo', 'Client', 'from_container',
+           'load_devices', 'cache']
 import logging
 from .device import Device, EntryInfo  # noqa
 from .client import Client  # noqa
-from .loader import load_devices, cache  # noqa
+from .loader import from_container, load_devices, cache  # noqa
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/happi/__init__.py
+++ b/happi/__init__.py
@@ -1,9 +1,9 @@
 __all__ = ['Device', 'EntryInfo', 'Client', 'from_container',
            'load_devices', 'cache']
 import logging
-from .device import Device, EntryInfo  # noqa
-from .client import Client  # noqa
-from .loader import from_container, load_devices, cache  # noqa
+from .device import Device, EntryInfo
+from .client import Client
+from .loader import from_container, load_devices, cache
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -43,10 +43,11 @@ class QSBackend(JSONBackend):
     Questionniare Backend
 
     This backend connects to the LCLS questionnaire and looks at devices with
-    the key pattern pcds-{}-setup-{}-{}. These fields are then combined and turned
-    into proper happi devices. The translation of table name to pcdsdevices
-    class is determined by the :attr:`.device_translations` dictionary. The
-    beamline is determined by looking where the proposal was submitted.
+    the key pattern pcds-{}-setup-{}-{}. These fields are then combined and
+    turned into proper happi devices. The translation of table name to
+    pcdsdevices class is determined by the :attr:`.device_translations`
+    dictionary. The beamline is determined by looking where the proposal was
+    submitted.
 
     Unlike the other backends, this one is read-only. All changes to the device
     information should be done via the web interface. Finally, in order to

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -43,7 +43,7 @@ class QSBackend(JSONBackend):
     Questionniare Backend
 
     This backend connects to the LCLS questionnaire and looks at devices with
-    the key pattern pcds-*-setup-*-*. These fields are then combined and turned
+    the key pattern pcds-{}-setup-{}-{}. These fields are then combined and turned
     into proper happi devices. The translation of table name to pcdsdevices
     class is determined by the :attr:`.device_translations` dictionary. The
     beamline is determined by looking where the proposal was submitted.

--- a/happi/client.py
+++ b/happi/client.py
@@ -217,7 +217,7 @@ class Client:
             Passed to :meth:`.Client.find_device`
 
         use_cache: bool, optional
-            Choice to use a cached device. See :meth:`.from_container for more
+            Choice to use a cached device. See :meth:`.from_container` for more
             information
 
         Returns

--- a/happi/client.py
+++ b/happi/client.py
@@ -8,6 +8,7 @@ from . import containers
 from .device import Device
 from .errors import EntryError, DatabaseError, SearchError
 from .backends import backend
+from .loader import from_container
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +199,34 @@ class Client:
         # Add the save method to the device
         device.save = lambda: self._store(device, insert=False)
         return device
+
+    def load_device(self, use_cache=True, **post):
+        """
+        Find a device in the database and instantiate it
+
+        Essentially a shortcut for:
+
+        .. code:: python
+
+            container = client.find_device(name='...')
+            device = from_container(container)
+
+        Parameters
+        ----------
+        post:
+            Passed to :meth:`.Client.find_device`
+
+        use_cache: bool, optional
+            Choice to use a cached device. See :meth:`.from_container for more
+            information
+
+        Returns
+        -------
+        obj:
+            Instantiated object
+        """
+        cntr = self.find_device(**post)
+        return from_container(cntr, use_cache=use_cache)
 
     def validate(self):
         """

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -44,7 +44,10 @@ def device_info():
             '_id': 'BASE:PV',
             'prefix': 'BASE:PV',
             'beamline': 'LCLS',
-            'type': 'Device'}
+            'type': 'Device',
+            'device_class': 'types.SimpleNamespace',
+            'args': list(),
+            'kwargs': {'hi': 'oh hello'}}
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import tempfile
+import types
 
 import pytest
 
@@ -206,3 +207,9 @@ class TestClient:
         # Cleanup
         os.remove(temp_path)
         os.close(fd)
+
+    def test_load_device(self, mc, device):
+        client = mc()
+        device = client.load_device(name=device.name)
+        assert isinstance(device, types.SimpleNamespace)
+        assert device.hi == 'oh hello'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
We didn't have the top level import for loading a single device -> `from_container`.

I kind of realized that this should be a default method on `Client`. I think the main reason I didn't is because I couldn't think of  a name. Thoughts on?

`find_device` -> search and return `happi.Device`
`load_device` -> search and return `ophyd.Device`

I think the reason I didn't do this before is in `happi` < `1.0.0`, `load_device` **was** a function that returned a `happi.Device`. I renamed it to avoid future confusion. 


Closes #72 