### PR TITLE
Happi Configuration File

### DIFF
--- a/happi/backends/__init__.py
+++ b/happi/backends/__init__.py
@@ -6,9 +6,16 @@ import os
 # override this by explicitly importing the backend
 _backend = os.environ.get("HAPPI_BACKEND", '').lower()
 
-if _backend == 'mongodb':
-    from .mongo_db import MongoBackend as backend
-else:
-    from .json_db import JSONBackend as backend
+
+def _get_backend(backend):
+    if backend == 'mongodb':
+        from .mongo_db import MongoBackend
+        return MongoBackend
+    else:
+        from .json_db import JSONBackend
+        return JSONBackend
+
+
+backend = _get_backend(_backend)
 
 del _backend

--- a/happi/backends/__init__.py
+++ b/happi/backends/__init__.py
@@ -4,16 +4,19 @@ import os
 # as an environment variable. Import this as the standard
 # backend for other places in the module. A user can always
 # override this by explicitly importing the backend
-_backend = os.environ.get("HAPPI_BACKEND", '').lower()
+_backend = os.environ.get("HAPPI_BACKEND", 'json').lower()
 
 
 def _get_backend(backend):
     if backend == 'mongodb':
         from .mongo_db import MongoBackend
         return MongoBackend
-    else:
+    elif backend == 'json':
         from .json_db import JSONBackend
         return JSONBackend
+    else:
+        raise ImportError("Improper specification of happi backend."
+                          "Check `$HAPPI_BACKEND` environment variable.")
 
 
 backend = _get_backend(_backend)

--- a/happi/client.py
+++ b/happi/client.py
@@ -456,6 +456,23 @@ class Client:
     def from_config(cls, cfg=None):
         """
         Create a client from a configuration file specification
+
+        Configuration files looking something along the lines of:
+
+        .. code::
+
+            [DEFAULT]
+            path=path/to/my/db.json
+
+        All key value pairs will be passed directly into backend construction
+        with the exception of the key ``backend`` which can be used to specify
+        a specific type of backend if this differs from the configured default.
+
+        Parameters
+        ----------
+        cfg: str, optional
+            Path to a configuration file. If not entered, :meth:`.find_config`
+            will be use.
         """
         # Find a configuration file
         if not cfg:
@@ -477,6 +494,22 @@ class Client:
     def find_config():
         """
         Search for a ``happi`` configuration file
+
+        We first query the environment variable ``$HAPPI_CFG`` to see if
+        this points to a specific configuration file. If this is not present,
+        the current working directory and the users home directory are searched
+        for a file named ``happi.cfg``
+
+        Returns
+        -------
+        path: str
+            Absolute path to configuration file
+
+        Raises
+        ------
+        EnvironmentError:
+            If no configuration file can be found by the methodology detailed
+            above
         """
         # Point to with an environment variable
         if os.environ.get('HAPPI_CFG', False):

--- a/happi/client.py
+++ b/happi/client.py
@@ -479,7 +479,8 @@ class Client:
             cfg = cls.find_config()
         # Parse configuration file
         cfg_parser = configparser.ConfigParser()
-        cfg_parser.read(cfg)
+        cfg_file = cfg_parser.read(cfg)
+        logger.debug("Loading configuration file at %r", cfg_file)
         db_info = cfg_parser['DEFAULT']
         # If a backend is specified use it, otherwise default
         if 'backend' in db_info:
@@ -487,6 +488,7 @@ class Client:
             db = _get_backend(db_str)
         else:
             db = backend
+        logger.debug("Using Happi backend %r", db)
         # Create our database with provided kwargs
         return cls(database=db(**dict(db_info.items())))
 
@@ -513,7 +515,10 @@ class Client:
         """
         # Point to with an environment variable
         if os.environ.get('HAPPI_CFG', False):
-            return os.environ.get('HAPPI_CFG')
+            happi_cfg = os.environ.get('HAPPI_CFG')
+            logger.debug("Found $HAPPI_CFG specification for Client "
+                         "configuration at %s", happi_cfg)
+            return happi_cfg
         # Search in the current directory and home directory
         else:
             for path in ('.happi.cfg', 'happi.cfg', '~/.happi.cfg'):

--- a/happi/client.py
+++ b/happi/client.py
@@ -518,7 +518,7 @@ class Client:
         else:
             for path in ('.happi.cfg', 'happi.cfg', '~/.happi.cfg'):
                 if os.path.exists(path):
-                    return os.path.abspath(path)
+                    return os.path.abspath(os.path.expanduser(path))
         # If found nothing
         raise EnvironmentError("No happi configuration file found. "
                                "Check HAPPI_CFG.")

--- a/happi/client.py
+++ b/happi/client.py
@@ -449,3 +449,20 @@ class Client:
         # Store information
         logger.info('Adding / Modifying information for %s ...', _id)
         self.backend.save(_id, post, insert=insert)
+
+    @staticmethod
+    def find_config():
+        """
+        Search for a ``happi`` configuration file
+        """
+        # Point to with an environment variable
+        if os.environ.get('HAPPI_CFG', False):
+            return os.environ.get('HAPPI_CFG')
+        # Search in the current directory and home directory
+        else:
+            for path in ('.happi.cfg', 'happi.cfg', '~/.happi.cfg'):
+                if os.path.exists(path):
+                    return os.path.abspath(path)
+        # If found nothing
+        raise EnvironmentError("No happi configuration file found. "
+                               "Check HAPPI_CFG.")

--- a/happi/client.py
+++ b/happi/client.py
@@ -497,10 +497,10 @@ class Client:
         """
         Search for a ``happi`` configuration file
 
-        We first query the environment variable ``$HAPPI_CFG`` to see if
-        this points to a specific configuration file. If this is not present,
-        the current working directory and the users home directory are searched
-        for a file named ``happi.cfg``
+        We first query the environment variable ``$HAPPI_CFG`` to see if this
+        points to a specific configuration file. If this is not present, the
+        variable set by ``$XDG_CONFIG_HOME`` or if  that is not set
+        ``~/.config``
 
         Returns
         -------
@@ -521,9 +521,14 @@ class Client:
             return happi_cfg
         # Search in the current directory and home directory
         else:
-            for path in ('.happi.cfg', 'happi.cfg', '~/.happi.cfg'):
-                if os.path.exists(path):
-                    return os.path.abspath(os.path.expanduser(path))
+            config_dir = (os.environ.get('XDG_CONFIG_HOME')
+                          or os.path.expanduser('~/.config'))
+            logger.debug('Searching for Happi config in %s', config_dir)
+            for path in ('.happi.cfg', 'happi.cfg'):
+                full_path = os.path.join(config_dir, path)
+                if os.path.exists(full_path):
+                    logger.debug("Found configuration file at %r", full_path)
+                    return full_path
         # If found nothing
         raise EnvironmentError("No happi configuration file found. "
                                "Check HAPPI_CFG.")

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -31,6 +31,7 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture(scope='function')
 def happi_cfg():
     fname = os.path.join(os.getcwd(), 'happi.cfg')
+    os.environ['XDG_CONFIG_HOME'] = os.getcwd()
     with open(fname, 'w+') as handle:
         handle.write("""\
 [DEFAULT]
@@ -229,7 +230,9 @@ class TestClient:
         assert device.hi == 'oh hello'
 
     def test_find_cfg(self, mc, happi_cfg):
+        # Use our config directory
         assert happi_cfg == Client.find_config()
+        # Set the path explicitly using HAPPI env variable
         os.environ['HAPPI_CFG'] = happi_cfg
         assert happi_cfg == Client.find_config()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
First whack at a persistent and simple way to setup a new `happi` client pointing to our deployed database. The basic issue is when I spawn a new process I don't want to have to keep track in a thousand different places the full path to the `JSON` file that contains my devices. This information will only get more complicated if we do things like: go to MongoDB, separate our single database into smaller hutch databases e.t.c

The solution I came up with is setting up a simple configuration file that looks like:

```ini
[DEFAULT]
backend=json
path=path/to/my/db.json
```
We then have an environment variable `HAPPI_DB` that points to the configuration file, and calling `happi.Client.from_config()` with no arguments will find this environment variable, load the configuration and return a ready-to-go `Client`. My thought is that we can setup this environment variable in our base `Conda` installation that way if you are in our Conda environment you are guaranteed for this to work. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #52 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for both types of `find_config` and `from_config`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings
