### PR TITLE
Additional Keywords

### DIFF
--- a/happi/device.py
+++ b/happi/device.py
@@ -272,6 +272,7 @@ class Device(metaclass=InfoMeta):
                        'enter the name', enforce=str)
     lightpath = EntryInfo("If the device should be included in the ",
                           "LCLS Lightpath", enforce=bool, default=False)
+    documentation = EntryInfo("Relevant documentation for the Device")
 
     def __init__(self, **kwargs):
         # Load given information into device class

--- a/happi/device.py
+++ b/happi/device.py
@@ -270,7 +270,7 @@ class Device(metaclass=InfoMeta):
                        enforce=str)
     parent = EntryInfo('If the device is a component of another, '
                        'enter the name', enforce=str)
-    lightpath = EntryInfo("If the device should be included in the ",
+    lightpath = EntryInfo("If the device should be included in the "
                           "LCLS Lightpath", enforce=bool, default=False)
     documentation = EntryInfo("Relevant documentation for the Device")
 

--- a/happi/device.py
+++ b/happi/device.py
@@ -270,6 +270,8 @@ class Device(metaclass=InfoMeta):
                        enforce=str)
     parent = EntryInfo('If the device is a component of another, '
                        'enter the name', enforce=str)
+    lightpath = EntryInfo("If the device should be included in the ",
+                          "LCLS Lightpath", enforce=bool, default=False)
 
     def __init__(self, **kwargs):
         # Load given information into device class

--- a/happi/device.py
+++ b/happi/device.py
@@ -272,7 +272,8 @@ class Device(metaclass=InfoMeta):
                        'enter the name', enforce=str)
     lightpath = EntryInfo("If the device should be included in the "
                           "LCLS Lightpath", enforce=bool, default=False)
-    documentation = EntryInfo("Relevant documentation for the Device")
+    documentation = EntryInfo("Relevant documentation for the Device",
+                              enforce=str)
 
     def __init__(self, **kwargs):
         # Load given information into device class


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds two new keywords:

**lightpath** - Easy key that makes it very transparent whether we should include this device in the LCLS Lightpath. I like this way better than keeping a big list of accepted classes. `active` always overrules this (i.e an inactive device with `ligthpath=True` will not be shown

**documentation** - Keeping this very ambiguous. Not sure what I really want it to look like in the end. It could be a string that points to a single url or a list of sources or a dictionary that has a keyword for each documenting source. This is also slightly awkward as what you probably want is to have this on a class basis, not a device? Maybe not? Not sure.. In any case it wouldn't be hard to write a little script:

```python
my_awesome_html ='www.wtf_is_wrong_with_this_motor.com'
for device in client.search(device_class='pcdsdevices.device_types.IMS'):
     if my_awesome_html not in device.documentation:
          device.documentation.append(my_awesome_html)
          device.save()
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #58 
Closes #72