### PR TITLE
Motor

### DIFF
--- a/docs/source/containers.rst
+++ b/docs/source/containers.rst
@@ -32,7 +32,7 @@ basis.
    happi.containers.PulsePicker
    happi.containers.LODCM
    happi.containers.MovableStand
-
+   happi.containers.Motor
 
 Loading Containers
 ------------------

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -12,32 +12,6 @@ from ..errors import DatabaseError
 logger = logging.getLogger(__name__)
 
 
-# Declare our motor types
-motor_types = {'MMS': 'pcdsdevices.epics_motor.IMS',
-               'MMN': 'pcdsdevices.epics_motor.Newport',
-               'MZM': 'pcdsdevices.epics_motor.PMC100'}
-
-
-def guess_motor_class(prefix):
-    """
-    Guess the corresponding pcdsdevices.epics_motor class based on prefix
-
-    Parameters
-    ----------
-    prefix : str
-
-    Returns
-    -------
-    device_class : str
-        Type of EpicsMotor. If not, we assume
-        `pcdsdevices.epics_motor.PCDSMotorBase`
-    """
-    for _typ in motor_types:
-        if _typ in prefix:
-            return motor_types[_typ]
-    return 'pcdsdevices.epics_motor.PCDSMotorBase'
-
-
 class QSBackend(JSONBackend):
     """
     Questionniare Backend
@@ -45,7 +19,7 @@ class QSBackend(JSONBackend):
     This backend connects to the LCLS questionnaire and looks at devices with
     the key pattern pcds-{}-setup-{}-{}. These fields are then combined and
     turned into proper happi devices. The translation of table name to
-    pcdsdevices class is determined by the :attr:`.device_translations`
+    ``happi.Container`` is determined by the :attr:`.device_translations`
     dictionary. The beamline is determined by looking where the proposal was
     submitted.
 
@@ -62,7 +36,7 @@ class QSBackend(JSONBackend):
     expname : str
         The experiment name from the elog, e.g. xcslp1915
     """
-    device_translations = {'motors': guess_motor_class}
+    device_translations = {'motors': 'Motor'}
 
     def __init__(self, expname, **kwargs):
         # Create our client and gather the raw information from the client
@@ -133,8 +107,7 @@ class QSBackend(JSONBackend):
                         post = {'name': dev_info.pop('name'),
                                 'prefix': dev_info['pvbase'],
                                 'beamline': beamline,
-                                'device_class': _class(dev_info['pvbase']),
-                                'type': 'Device',
+                                'type': _class,
                                 # TODO: We should not assume that we are using
                                 # the prefix as _id. Other backends do not make
                                 # this assumption. This will require moving the

--- a/happi/containers.py
+++ b/happi/containers.py
@@ -287,3 +287,13 @@ class MovableStand(Device):
     stand.enforce = list
     system = copy(Device.system)
     system.default = 'changeover'
+
+
+class Motor(Device):
+    """
+    A Generic EpicsMotor
+    """
+    device_class = copy(Device.device_class)
+    device_class.default = 'pcdsdevices.device_types.Motor'
+    system = copy(Device.system)
+    system.default = 'motion'

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -157,9 +157,3 @@ def test_qsbackend_with_client(mockqsbackend):
     assert len(c.all_devices) == 6
     assert all([d.device_class == 'pcdsdevices.epics_motor.IMS'
                 for d in c.all_devices])
-
-
-@requires_questionnaire
-def test_guess_motor_class():
-    from happi.backends.qs_db import guess_motor_class
-    assert guess_motor_class('Tst:MMN:01') == 'pcdsdevices.epics_motor.Newport'

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -155,5 +155,5 @@ def test_qs_find(mockqsbackend):
 def test_qsbackend_with_client(mockqsbackend):
     c = Client(database=mockqsbackend)
     assert len(c.all_devices) == 6
-    assert all([d.device_class == 'pcdsdevices.epics_motor.IMS'
+    assert all([d.device_class == 'pcdsdevices.device_types.Motor'
                 for d in c.all_devices])

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -10,6 +10,7 @@ from .conftest import (requires_questionnaire, requires_mongomock,
 from happi.backends.json_db import JSONBackend
 from happi.errors import DuplicateError, SearchError
 from happi import Client
+from happi.containers import Motor
 
 
 @pytest.fixture(scope='function')
@@ -155,5 +156,4 @@ def test_qs_find(mockqsbackend):
 def test_qsbackend_with_client(mockqsbackend):
     c = Client(database=mockqsbackend)
     assert len(c.all_devices) == 6
-    assert all([d.device_class == 'pcdsdevices.device_types.Motor'
-                for d in c.all_devices])
+    assert all([isinstance(d, Motor) for d in c.all_devices])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a generic `Motor` container. By default this points to the factory created in https://github.com/pcdshub/pcdsdevices/pull/306. 

There was also some code that in the Questionnaire Backend that essentially had the same logic as the factory. This is obviously the wrong place to put this as if we scramble around our motor classes we need to remember the 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #57 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to autosummary