### PR TITLE
Windows Import

### DIFF
--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -15,11 +15,9 @@ logger = logging.getLogger(__name__)
 
 try:
     import fcntl
-    on_unix = True
 except ImportError:
     logger.warning("Unable to import 'fcntl'. Will be unable to lock files")
-    on_unix = False
-
+    fcntl = None
 
 class JSONBackend(metaclass=Backend):
     """
@@ -96,14 +94,14 @@ class JSONBackend(metaclass=Backend):
         # Create file handle
         handle = open(self.path, 'w+')
         # Create lock in filesystem
-        if on_unix:
+        if fcntl is not None:
             fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
         # Dump to file
         try:
             json.dump(db, handle, sort_keys=True, indent=4)
 
         finally:
-            if on_unix:
+            if fcntl is not None:
                 # Release lock in filesystem
                 fcntl.flock(handle, fcntl.LOCK_UN)
 

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -2,7 +2,6 @@
 Backend implemenation using simplejson
 """
 import os
-import fcntl
 import os.path
 import logging
 
@@ -12,6 +11,14 @@ from .core import Backend
 from ..errors import SearchError, DuplicateError
 
 logger = logging.getLogger(__name__)
+
+
+try:
+    import fcntl
+    on_unix = True
+except ImportError:
+    logger.warning("Unable to import 'fcntl'. Will be unable to lock files")
+    on_unix = False
 
 
 class JSONBackend(metaclass=Backend):
@@ -89,14 +96,16 @@ class JSONBackend(metaclass=Backend):
         # Create file handle
         handle = open(self.path, 'w+')
         # Create lock in filesystem
-        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if on_unix:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
         # Dump to file
         try:
             json.dump(db, handle, sort_keys=True, indent=4)
 
         finally:
-            # Release lock in filesystem
-            fcntl.flock(handle, fcntl.LOCK_UN)
+            if on_unix:
+                # Release lock in filesystem
+                fcntl.flock(handle, fcntl.LOCK_UN)
 
     def find(self, _id=None, multiples=False, **kwargs):
         """

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -19,6 +19,7 @@ except ImportError:
     logger.warning("Unable to import 'fcntl'. Will be unable to lock files")
     fcntl = None
 
+
 class JSONBackend(metaclass=Backend):
     """
     JSON database

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -5,8 +5,7 @@ import os.path
 import pytest
 import simplejson
 
-from .conftest import (requires_questionnaire, requires_mongomock,
-                       mockmongoclient)
+from .conftest import requires_questionnaire, requires_mongomock
 from happi.backends.json_db import JSONBackend
 from happi.errors import DuplicateError, SearchError
 from happi import Client
@@ -14,8 +13,8 @@ from happi.containers import Motor
 
 
 @pytest.fixture(scope='function')
-def mockmongo():
-    return mockmongoclient().backend
+def mockmongo(mockmongoclient):
+    return mockmongoclient.backend
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -9,23 +9,8 @@ from happi import Client, Device
 from happi.backends.json_db import JSONBackend
 from happi.containers import GateValve
 from happi.errors import SearchError, DuplicateError, EntryError
-from .conftest import has_mongomock, mockmongoclient, mockjsonclient
 
 logger = logging.getLogger(__name__)
-
-
-def pytest_generate_tests(metafunc):
-    idlist = []
-    argvalues = []
-    # Select clients for current environment
-    clients = [('json', mockjsonclient)]
-    if has_mongomock:
-        clients.append(('mongo', mockmongoclient))
-    # Load clients into test suite
-    for case in clients:
-        idlist.append(case[0])
-        argvalues.append(case[1])
-    metafunc.parametrize('mc', argvalues, ids=idlist, scope='class')
 
 
 @pytest.fixture(scope='function')
@@ -51,201 +36,198 @@ path=db.json
     os.remove(fname)
 
 
-class TestClient:
+def test_find_document(happi_client, device_info):
+    doc = happi_client.find_document(**device_info)
+    assert doc.pop('prefix') == device_info['prefix']
+    assert doc.pop('name') == device_info['name']
+    assert doc.pop('z') == device_info['z']
+    assert doc.pop('beamline') == device_info['beamline']
+    # Remove id and check
+    prefix = device_info.pop('prefix')
+    doc = happi_client.find_document(**device_info)
 
-    def teardown_method(self, method):
-        if os.path.exists('testing.json'):
-            os.remove('testing.json')
+    assert doc.pop('prefix') == prefix
+    assert doc.pop('name') == device_info['name']
+    assert doc.pop('z') == device_info['z']
+    assert doc.pop('beamline') == device_info['beamline']
+    # Not available
+    with pytest.raises(SearchError):
+        doc = happi_client.find_document(prefix='Does not Exist')
 
-    def test_find_document(self, mc, device_info):
-        client = mc()
-        doc = client.find_document(**device_info)
-        assert doc.pop('prefix') == device_info['prefix']
-        assert doc.pop('name') == device_info['name']
-        assert doc.pop('z') == device_info['z']
-        assert doc.pop('beamline') == device_info['beamline']
-        # Remove id and check
-        prefix = device_info.pop('prefix')
-        doc = client.find_document(**device_info)
 
-        assert doc.pop('prefix') == prefix
-        assert doc.pop('name') == device_info['name']
-        assert doc.pop('z') == device_info['z']
-        assert doc.pop('beamline') == device_info['beamline']
-        # Not available
-        with pytest.raises(SearchError):
-            doc = client.find_document(prefix='Does not Exist')
+def test_create_device(happi_client, device_info):
+    device = happi_client.create_device(Device, **device_info)
+    assert device.prefix == device_info['prefix']
+    assert device.name == device_info['name']
+    assert device.z == device_info['z']
+    assert device.beamline == device_info['beamline']
+    # Invalid Entry
+    with pytest.raises(TypeError):
+        happi_client.create_device(int)
 
-    def test_create_device(self, mc, device_info):
-        client = mc()
-        device = client.create_device(Device, **device_info)
-        assert device.prefix == device_info['prefix']
-        assert device.name == device_info['name']
-        assert device.z == device_info['z']
-        assert device.beamline == device_info['beamline']
-        # Invalid Entry
-        with pytest.raises(TypeError):
-            client.create_device(int)
 
-    def test_create_valve(self, mc, valve_info):
-        client = mc()
-        device = client.create_device(GateValve, **valve_info)
-        assert isinstance(device, GateValve)
-        assert device.prefix == valve_info['prefix']
-        assert device.name == valve_info['name']
-        assert device.z == valve_info['z']
-        assert device.beamline == valve_info['beamline']
-        # Specify string as class
-        device = client.create_device('GateValve', **valve_info)
-        assert isinstance(device, GateValve)
-        assert device.prefix == valve_info['prefix']
-        assert device.name == valve_info['name']
-        assert device.z == valve_info['z']
-        assert device.beamline == valve_info['beamline']
-        # Save
-        device.save()
-        loaded_device = client.find_device(**valve_info)
-        assert loaded_device.prefix == valve_info['prefix']
-        assert loaded_device.name == valve_info['name']
-        assert loaded_device.z == valve_info['z']
-        assert loaded_device.beamline == valve_info['beamline']
+def test_create_valve(happi_client, valve_info):
+    device = happi_client.create_device(GateValve, **valve_info)
+    assert isinstance(device, GateValve)
+    assert device.prefix == valve_info['prefix']
+    assert device.name == valve_info['name']
+    assert device.z == valve_info['z']
+    assert device.beamline == valve_info['beamline']
+    # Specify string as class
+    device = happi_client.create_device('GateValve', **valve_info)
+    assert isinstance(device, GateValve)
+    assert device.prefix == valve_info['prefix']
+    assert device.name == valve_info['name']
+    assert device.z == valve_info['z']
+    assert device.beamline == valve_info['beamline']
+    # Save
+    device.save()
+    loaded_device = happi_client.find_device(**valve_info)
+    assert loaded_device.prefix == valve_info['prefix']
+    assert loaded_device.name == valve_info['name']
+    assert loaded_device.z == valve_info['z']
+    assert loaded_device.beamline == valve_info['beamline']
 
-    def test_all_devices(self, mc, device):
-        client = mc()
-        assert client.all_devices == [device]
 
-    def test_add_device(self, mc, valve, device, valve_info):
-        client = mc()
-        client.add_device(valve)
-        doc = client.backend.find(multiples=False, **valve_info)
-        assert valve.prefix == doc['prefix']
-        assert valve.name == doc['name']
-        assert valve.z == doc['z']
-        assert valve.beamline == doc['beamline']
-        # No duplicates
-        with pytest.raises(DuplicateError):
-            client.add_device(device)
-        # No incompletes
-        d = Device()
-        with pytest.raises(EntryError):
-            client.add_device(d)
+def test_all_devices(happi_client, device):
+    assert happi_client.all_devices == [device]
 
-    def test_add_and_find_device(self, mc, valve, valve_info):
-        client = mc()
-        client.add_device(valve)
-        loaded_device = client.find_device(**valve_info)
-        assert loaded_device.prefix == valve.prefix
-        assert loaded_device.name == valve.name
-        assert loaded_device.z == valve.z
-        assert loaded_device.beamline == valve.beamline
 
-    def test_find_device(self, mc, device_info):
-        client = mc()
-        device = client.find_device(**device_info)
-        assert isinstance(device, Device)
-        assert device.prefix == device_info['prefix']
-        assert device.name == device_info['name']
-        assert device.z == device_info['z']
-        assert device.beamline == device_info['beamline']
-        # Test edit and save
-        device.stand = 'DG3'
-        device.save()
-        loaded_device = client.find_device(**device_info)
-        assert loaded_device.prefix == device_info['prefix']
-        assert loaded_device.name == device_info['name']
-        assert loaded_device.z == device_info['z']
-        assert loaded_device.beamline == device_info['beamline']
-        assert loaded_device.stand == 'DG3'
-        # Bad load
-        bad = {'a': 'b'}
-        client.backend.save('a', bad, insert=True)
-        with pytest.raises(EntryError):
-            client.find_device(**bad)
+def test_add_device(happi_client, valve, device, valve_info):
+    happi_client.add_device(valve)
+    doc = happi_client.backend.find(multiples=False, **valve_info)
+    assert valve.prefix == doc['prefix']
+    assert valve.name == doc['name']
+    assert valve.z == doc['z']
+    assert valve.beamline == doc['beamline']
+    # No duplicates
+    with pytest.raises(DuplicateError):
+        happi_client.add_device(device)
+    # No incompletes
+    d = Device()
+    with pytest.raises(EntryError):
+        happi_client.add_device(d)
 
-    def test_validate(self, mc):
-        client = mc()
-        # No bad devices
-        assert client.validate() == list()
-        # A single bad device
-        client.backend.save('_id', {'prefix': 'bad'}, insert=True)
-        assert client.validate() == ['bad']
 
-    def test_search(self, mc, device, valve, device_info, valve_info):
-        client = mc()
-        client.add_device(valve)
-        res = client.search(name=device_info['name'])
-        # Single search return
-        assert len(res) == 1
-        loaded_device = res[0]
-        assert loaded_device.prefix == device_info['prefix']
-        assert loaded_device.name == device_info['name']
-        assert loaded_device.z == device_info['z']
-        assert loaded_device.beamline == device_info['beamline']
-        # No results
-        assert client.search(name='not') is None
-        # Returned as dict
-        res = client.search(as_dict=True, **device_info)
-        loaded_device = res[0]
-        assert loaded_device['prefix'] == device_info['prefix']
-        assert loaded_device['name'] == device_info['name']
-        assert loaded_device['z'] == device_info['z']
-        assert loaded_device['beamline'] == device_info['beamline']
-        # Search between two points
-        res = client.search(start=0, end=500)
-        assert len(res) == 2
-        loaded_device = res[0]
-        # Search between two points, nothing found
-        res = client.search(start=10000, end=500000)
-        assert res is None
-        # Search without an endpoint
-        res = client.search(start=0)
-        assert len(res) == 2
-        loaded_device = res[1]
-        # Search invalid range
-        with pytest.raises(ValueError):
-            client.search(start=1000, end=5)
-        # Search off keyword
-        res = client.search(beamline='LCLS')
-        assert len(res) == 2
+def test_add_and_find_device(happi_client, valve, valve_info):
+    happi_client.add_device(valve)
+    loaded_device = happi_client.find_device(**valve_info)
+    assert loaded_device.prefix == valve.prefix
+    assert loaded_device.name == valve.name
+    assert loaded_device.z == valve.z
+    assert loaded_device.beamline == valve.beamline
 
-    def test_remove_device(self, mc, device, valve, device_info):
-        client = mc()
-        client.remove_device(device)
-        assert client.backend.find(**device_info) == []
-        # Invalid Device
-        with pytest.raises(ValueError):
-            client.remove_device(5)
-        # Valve not in dictionary
-        with pytest.raises(SearchError):
-            client.remove_device(valve)
 
-    def test_export(self, mc, valve):
-        client = mc()
-        # Setup client with both devices
-        client.add_device(valve)
-        fd, temp_path = tempfile.mkstemp()
-        client.export(open(temp_path, 'w+'), sep=',', attrs=['name', 'prefix'])
-        exp = open(temp_path, 'r').read()
-        assert "alias,BASE:PV" in exp
-        assert "name,BASE:VGC:PV" in exp
-        # Cleanup
-        os.remove(temp_path)
-        os.close(fd)
+def test_find_device(happi_client, device_info):
+    device = happi_client.find_device(**device_info)
+    assert isinstance(device, Device)
+    assert device.prefix == device_info['prefix']
+    assert device.name == device_info['name']
+    assert device.z == device_info['z']
+    assert device.beamline == device_info['beamline']
+    # Test edit and save
+    device.stand = 'DG3'
+    device.save()
+    loaded_device = happi_client.find_device(**device_info)
+    assert loaded_device.prefix == device_info['prefix']
+    assert loaded_device.name == device_info['name']
+    assert loaded_device.z == device_info['z']
+    assert loaded_device.beamline == device_info['beamline']
+    assert loaded_device.stand == 'DG3'
+    # Bad load
+    bad = {'a': 'b'}
+    happi_client.backend.save('a', bad, insert=True)
+    with pytest.raises(EntryError):
+        happi_client.find_device(**bad)
 
-    def test_load_device(self, mc, device):
-        client = mc()
-        device = client.load_device(name=device.name)
-        assert isinstance(device, types.SimpleNamespace)
-        assert device.hi == 'oh hello'
 
-    def test_find_cfg(self, mc, happi_cfg):
-        # Use our config directory
-        assert happi_cfg == Client.find_config()
-        # Set the path explicitly using HAPPI env variable
-        os.environ['HAPPI_CFG'] = happi_cfg
-        assert happi_cfg == Client.find_config()
+def test_validate(happi_client):
+    # No bad devices
+    assert happi_client.validate() == list()
+    # A single bad device
+    happi_client.backend.save('_id', {'prefix': 'bad'}, insert=True)
+    assert happi_client.validate() == ['bad']
 
-    def test_from_cfg(self, mc, happi_cfg):
-        client = Client.from_config()
-        assert isinstance(client.backend, JSONBackend)
-        assert client.backend.path == 'db.json'
+
+def test_search(happi_client, device, valve, device_info, valve_info):
+    happi_client.add_device(valve)
+    res = happi_client.search(name=device_info['name'])
+    # Single search return
+    assert len(res) == 1
+    loaded_device = res[0]
+    assert loaded_device.prefix == device_info['prefix']
+    assert loaded_device.name == device_info['name']
+    assert loaded_device.z == device_info['z']
+    assert loaded_device.beamline == device_info['beamline']
+    # No results
+    assert happi_client.search(name='not') is None
+    # Returned as dict
+    res = happi_client.search(as_dict=True, **device_info)
+    loaded_device = res[0]
+    assert loaded_device['prefix'] == device_info['prefix']
+    assert loaded_device['name'] == device_info['name']
+    assert loaded_device['z'] == device_info['z']
+    assert loaded_device['beamline'] == device_info['beamline']
+    # Search between two points
+    res = happi_client.search(start=0, end=500)
+    assert len(res) == 2
+    loaded_device = res[0]
+    # Search between two points, nothing found
+    res = happi_client.search(start=10000, end=500000)
+    assert res is None
+    # Search without an endpoint
+    res = happi_client.search(start=0)
+    assert len(res) == 2
+    loaded_device = res[1]
+    # Search invalid range
+    with pytest.raises(ValueError):
+        happi_client.search(start=1000, end=5)
+    # Search off keyword
+    res = happi_client.search(beamline='LCLS')
+    assert len(res) == 2
+
+
+def test_remove_device(happi_client, device, valve, device_info):
+    happi_client.remove_device(device)
+    assert happi_client.backend.find(**device_info) == []
+    # Invalid Device
+    with pytest.raises(ValueError):
+        happi_client.remove_device(5)
+    # Valve not in dictionary
+    with pytest.raises(SearchError):
+        happi_client.remove_device(valve)
+
+
+def test_export(happi_client, valve):
+    # Setup client with both devices
+    happi_client.add_device(valve)
+    fd, temp_path = tempfile.mkstemp()
+    happi_client.export(open(temp_path, 'w+'),
+                        sep=',',
+                        attrs=['name', 'prefix'])
+    exp = open(temp_path, 'r').read()
+    assert "alias,BASE:PV" in exp
+    assert "name,BASE:VGC:PV" in exp
+    # Cleanup
+    os.remove(temp_path)
+    os.close(fd)
+
+
+def test_load_device(happi_client, device):
+    device = happi_client.load_device(name=device.name)
+    assert isinstance(device, types.SimpleNamespace)
+    assert device.hi == 'oh hello'
+
+
+def test_find_cfg(happi_cfg):
+    # Use our config directory
+    assert happi_cfg == Client.find_config()
+    # Set the path explicitly using HAPPI env variable
+    os.environ['HAPPI_CFG'] = happi_cfg
+    assert happi_cfg == Client.find_config()
+
+
+def test_from_cfg(happi_cfg):
+    client = Client.from_config()
+    assert isinstance(client.backend, JSONBackend)
+    assert client.backend.path == 'db.json'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* `fcntl` is not importable on Windows. We do not plan to support or test on Windows, but the package should at least be importable and there isn't a real fundamental reason that the `JSON` backend shouldn't work on any operating system. 
* The testing suite was kind of a mess. We were using fixtures improperly, calling them as regular functions. In `pytest>=4.0` this now explodes. This is now handled better, using a more elegant fixture pattern.

Attn. @tacaswell