### PR TITLE
Questionnaire more devices

### DIFF
--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -108,10 +108,6 @@ class QSBackend(JSONBackend):
                     if dev_no not in devices:
                         devices[dev_no] = dict()
                     devices[dev_no][match_analog.group(2)] = raw[field]
-#            print(table)
-#            print(devices)
-#            print(len(devices))
-#            print('')
             # Store the devices as happi items
             if not devices:
                 logger.info("No device information found under '%s'", table)

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -36,9 +36,9 @@ class QSBackend(JSONBackend):
     expname : str
         The experiment name from the elog, e.g. xcslp1915
     """
-    device_translations = {'motors': 'Motor', 'areadet': 'AreaDetector',
-                           'camera': 'AreaDetector', 'ao': 'Acromag',
-                           'ai': 'Acromag', 'trig': 'Trigger'}
+    device_translations = {'motors': 'Motor', 'camera': 'AreaDetector',
+                           'ao': 'Acromag', 'ai': 'Acromag',
+                           'trig': 'Trigger'}
 
     def __init__(self, expname, **kwargs):
         # Create our client and gather the raw information from the client
@@ -83,19 +83,13 @@ class QSBackend(JSONBackend):
         raw = self.qs.getProposalDetailsForRun(run_no, proposal)
         for table, _class in self.device_translations.items():
             # Create a regex pattern to find all the appropriate pattern match
-            # example pattern for non-AO devices:
-            # 'pcdssetup-camera-setup-1-purpose'
-            # example pattern for AO devices:
-            # 'pcdssetup-ao-1-purpose'
             pattern = re.compile(r'pcdssetup-{}-'
                                  r'setup-(\d+)-(\w+)'.format(table))
-            pattern_analog = re.compile(r'pcdssetup-{}-'
-                                        r'(\d+)-(\w+)'.format(table))
             # Search for all keys that match the device and store in a
             # temporary dictionary
             devices = dict()
             for field in raw.keys():
-                match = pattern.match(field) or pattern_analog.match(field)
+                match = pattern.match(field)
                 if match:
                     dev_no = match.group(1)
                     # Create an empty dictionary for the specific device

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -36,7 +36,9 @@ class QSBackend(JSONBackend):
     expname : str
         The experiment name from the elog, e.g. xcslp1915
     """
-    device_translations = {'motors': 'Motor', 'areadet': 'AreaDet', 'camera': 'Camera', 'ao': 'Acromag', 'ai':'Acromag', 'trig': 'ControlsTriggers'}
+    device_translations = {'motors': 'Motor', 'areadet': 'AreaDet',
+                           'camera': 'Camera', 'ao': 'Acromag',
+                           'ai': 'Acromag', 'trig': 'ControlsTriggers'}
 
     def __init__(self, expname, **kwargs):
         # Create our client and gather the raw information from the client
@@ -82,13 +84,13 @@ class QSBackend(JSONBackend):
         for table, _class in self.device_translations.items():
             # Create a regex pattern to find all the appropriate pattern match
             # example pattern for non-AO devices:
-            ### 'pcdssetup-camera-setup-1-purpose'
+            # 'pcdssetup-camera-setup-1-purpose'
             # example pattern for AO devices:
-            ### 'pcdssetup-ao-1-purpose'
+            # 'pcdssetup-ao-1-purpose'
             pattern = re.compile(r'pcdssetup-{}-'
                                  r'setup-(\d+)-(\w+)'.format(table))
             pattern_analog = re.compile(r'pcdssetup-{}-'
-                                 r'(\d+)-(\w+)'.format(table))
+                                        r'(\d+)-(\w+)'.format(table))
             # Search for all keys that match the device and store in a
             # temporary dictionary
             devices = dict()

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -36,9 +36,9 @@ class QSBackend(JSONBackend):
     expname : str
         The experiment name from the elog, e.g. xcslp1915
     """
-    device_translations = {'motors': 'Motor', 'areadet': 'AreaDet',
-                           'camera': 'Camera', 'ao': 'Acromag',
-                           'ai': 'Acromag', 'trig': 'ControlsTriggers'}
+    device_translations = {'motors': 'Motor', 'areadet': 'AreaDetector',
+                           'camera': 'AreaDetector', 'ao': 'Acromag',
+                           'ai': 'Acromag', 'trig': 'Trigger'}
 
     def __init__(self, expname, **kwargs):
         # Create our client and gather the raw information from the client

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -93,7 +93,7 @@ class QSBackend(JSONBackend):
             # temporary dictionary
             devices = dict()
             for field in raw.keys():
-                match = pattern.match(field)
+                match = pattern.match(field) or pattern_analog.match(field)
                 if match:
                     dev_no = match.group(1)
                     # Create an empty dictionary for the specific device
@@ -102,12 +102,6 @@ class QSBackend(JSONBackend):
                         devices[dev_no] = dict()
                     # Add the key information to the specific device dictionary
                     devices[dev_no][match.group(2)] = raw[field]
-                match_analog = pattern_analog.match(field)
-                if match_analog:
-                    dev_no = match_analog.group(1)
-                    if dev_no not in devices:
-                        devices[dev_no] = dict()
-                    devices[dev_no][match_analog.group(2)] = raw[field]
             # Store the devices as happi items
             if not devices:
                 logger.info("No device information found under '%s'", table)

--- a/happi/containers.py
+++ b/happi/containers.py
@@ -297,3 +297,43 @@ class Motor(Device):
     device_class.default = 'pcdsdevices.device_types.Motor'
     system = copy(Device.system)
     system.default = 'motion'
+
+
+class Camera(Device):
+    """
+    A Generic EpicsCamera
+    """
+    device_class = copy(Device.device_class)
+    device_class.default = 'pcdsdevices.device_types.Camera'
+    system = copy(Device.system)
+    system.default = 'cameras'
+
+
+class AreaDetector(Device):
+    """
+    A Generic EpicsAreaDetector
+    """
+    device_class = copy(Device.device_class)
+    device_class.default = 'pcdsdevices.device_types.AreaDetector'
+    system = copy(Device.system)
+    system.default = 'detectors'
+
+
+class Acromag(Device):
+    """
+    A Generic class for Acromag
+    """
+    device_class = copy(Device.device_class)
+    device_class.default = 'pcdsdevices.device_types.Acromag'
+    system = copy(Device.system)
+    system.default = 'acromag'
+
+
+class ControlsTriggers(Device):
+    """
+    A Generic class for Controls Triggers
+    """
+    device_class = copy(Device.device_class)
+    device_class.default = 'pcdsdevices.device_types.ControlsTriggers'
+    system = copy(Device.system)
+    system.default = 'triggers'

--- a/happi/containers.py
+++ b/happi/containers.py
@@ -299,24 +299,14 @@ class Motor(Device):
     system.default = 'motion'
 
 
-class Camera(Device):
+class AreaDetector(Device):
     """
     A Generic EpicsCamera
     """
     device_class = copy(Device.device_class)
-    device_class.default = 'pcdsdevices.device_types.Camera'
+    device_class.default = 'pcdsdevices.device_types.PCDSDetector'
     system = copy(Device.system)
-    system.default = 'cameras'
-
-
-class AreaDetector(Device):
-    """
-    A Generic EpicsAreaDetector
-    """
-    device_class = copy(Device.device_class)
-    device_class.default = 'pcdsdevices.device_types.AreaDetector'
-    system = copy(Device.system)
-    system.default = 'detectors'
+    system.default = 'camera'
 
 
 class Acromag(Device):
@@ -329,11 +319,11 @@ class Acromag(Device):
     system.default = 'acromag'
 
 
-class ControlsTriggers(Device):
+class Trigger(Device):
     """
     A Generic class for Controls Triggers
     """
     device_class = copy(Device.device_class)
-    device_class.default = 'pcdsdevices.device_types.ControlsTriggers'
+    device_class.default = 'pcdsdevices.device_types.Trigger'
     system = copy(Device.system)
-    system.default = 'triggers'
+    system.default = 'trigger'

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -116,7 +116,8 @@ def mockqsbackend():
 
         def getProposalsListForRun(self, run):
             return {'X534': {'Instrument': 'TST', 'proposal_id': 'X534'},
-                    'LR32': {'Instrument': 'TST', 'proposal_id': 'LR32'}}
+                    'LR32': {'Instrument': 'TST', 'proposal_id': 'LR32'},
+                    'LU34': {'Instrument': 'MFX', 'proposal_id': 'LU34'}}
 
         def getProposalDetailsForRun(self, run_no, proposal):
             return {
@@ -153,12 +154,48 @@ def mockqsbackend():
                 'pcdssetup-motors-setup-6-name': 'sam_flip',
                 'pcdssetup-motors-setup-6-purpose': 'sample flip',
                 'pcdssetup-motors-setup-6-pvbase': 'TST:USR:MMS:06',
-                'pcdssetup-motors-setup-6-stageidentity': 'IMS MD23'}
+                'pcdssetup-motors-setup-6-stageidentity': 'IMS MD23',
+                'pcdssetup-camera-setup-1-purpose': 'Meniscus',
+                'pcdssetup-camera-setup-1-trigger': '<=10',
+                'pcdssetup-camera-setup-1-type': 'Manta-G146C',
+                'pcdssetup-camera-setup-1-alias': 'MfxMeniscus',
+                'pcdssetup-camera-setup-2-purpose': 'Overview 1',
+                'pcdssetup-camera-setup-2-trigger': '<=10',
+                'pcdssetup-camera-setup-2-type': 'Manta-G145B',
+                'pcdssetup-camera-setup-2-alias': 'LBLOver1',
+                'pcdssetup-camera-setup-3-purpose': 'Side view',
+                'pcdssetup-camera-setup-3-trigger': '<=10',
+                'pcdssetup-camera-setup-3-type': 'Manta-G145B',
+                'pcdssetup-camera-setup-3-alias': 'LBLSide',
+                'pcdssetup-camera-setup-4-purpose': 'Inline',
+                'pcdssetup-camera-setup-4-trigger': '<=10',
+                'pcdssetup-camera-setup-4-type': 'Manta-G145B',
+                'pcdssetup-camera-setup-4-alias': 'LBLInline',
+                'pcdssetup-camera-setup-5-purpose': 'Overview 2',
+                'pcdssetup-camera-setup-5-trigger': '<=10',
+                'pcdssetup-camera-setup-5-type': 'Manta-G145B',
+                'pcdssetup-camera-setup-5-alias': 'LBLOver2',
+                'pcdssetup-trig-setup-1-delay': '0.00089',
+                'pcdssetup-trig-setup-1-eventcode': '198',
+                'pcdssetup-trig-setup-1-name': 'Overview_trig',
+                'pcdssetup-trig-setup-1-polarity': 'positive',
+                'pcdssetup-trig-setup-1-purpose': 'Overview',
+                'pcdssetup-trig-setup-1-pvbase': 'MFX:REC:EVR:02:TRIG1',
+                'pcdssetup-trig-setup-1-width': '0.00075',
+                'pcdssetup-trig-setup-2-delay': '0.000894348',
+                'pcdssetup-trig-setup-2-eventcode': '198',
+                'pcdssetup-trig-setup-2-name': 'Meniscus_trig',
+                'pcdssetup-trig-setup-2-polarity': 'positive',
+                'pcdssetup-trig-setup-2-purpose': 'Meniscus',
+                'pcdssetup-trig-setup-2-pvbase': 'MFX:REC:EVR:02:TRIG3',
+                'pcdssetup-trig-setup-2-width': '0.0005'}
+                # TODO: Add ao/ai devices once questionnaire is patched
 
         def getExpName2URAWIProposalIDs(self):
             return {
                 'tstx53416': 'X534',
-                'tstlr3216': 'LR32'}
+                'tstlr3216': 'LR32',
+                'mfxlu3417': 'LU34'}
 
     with patch('happi.backends.qs_db.QuestionnaireClient') as qs_cli:
         # Replace QuestionnaireClient with our test version

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -155,26 +155,6 @@ def mockqsbackend():
                 'pcdssetup-motors-setup-6-purpose': 'sample flip',
                 'pcdssetup-motors-setup-6-pvbase': 'TST:USR:MMS:06',
                 'pcdssetup-motors-setup-6-stageidentity': 'IMS MD23',
-                'pcdssetup-camera-setup-1-purpose': 'Meniscus',
-                'pcdssetup-camera-setup-1-trigger': '<=10',
-                'pcdssetup-camera-setup-1-type': 'Manta-G146C',
-                'pcdssetup-camera-setup-1-alias': 'MfxMeniscus',
-                'pcdssetup-camera-setup-2-purpose': 'Overview 1',
-                'pcdssetup-camera-setup-2-trigger': '<=10',
-                'pcdssetup-camera-setup-2-type': 'Manta-G145B',
-                'pcdssetup-camera-setup-2-alias': 'LBLOver1',
-                'pcdssetup-camera-setup-3-purpose': 'Side view',
-                'pcdssetup-camera-setup-3-trigger': '<=10',
-                'pcdssetup-camera-setup-3-type': 'Manta-G145B',
-                'pcdssetup-camera-setup-3-alias': 'LBLSide',
-                'pcdssetup-camera-setup-4-purpose': 'Inline',
-                'pcdssetup-camera-setup-4-trigger': '<=10',
-                'pcdssetup-camera-setup-4-type': 'Manta-G145B',
-                'pcdssetup-camera-setup-4-alias': 'LBLInline',
-                'pcdssetup-camera-setup-5-purpose': 'Overview 2',
-                'pcdssetup-camera-setup-5-trigger': '<=10',
-                'pcdssetup-camera-setup-5-type': 'Manta-G145B',
-                'pcdssetup-camera-setup-5-alias': 'LBLOver2',
                 'pcdssetup-trig-setup-1-delay': '0.00089',
                 'pcdssetup-trig-setup-1-eventcode': '198',
                 'pcdssetup-trig-setup-1-name': 'Overview_trig',
@@ -189,7 +169,12 @@ def mockqsbackend():
                 'pcdssetup-trig-setup-2-purpose': 'Meniscus',
                 'pcdssetup-trig-setup-2-pvbase': 'MFX:REC:EVR:02:TRIG3',
                 'pcdssetup-trig-setup-2-width': '0.0005'}
-                # TODO: Add ao/ai devices once questionnaire is patched
+# TODO: Add ao/ai devices once questionnaire is patched
+# NOTE: Unsure what to do with cameras, they won't get
+#       added without having PV's
+# Goal: Load cameras, ao/ai's, triggers from questionnaire
+# Now: Only getting triggers:
+# Need questionnaire patch for ao/ai's, PV's for cams
 
         def getExpName2URAWIProposalIDs(self):
             return {

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -9,7 +9,7 @@ from .conftest import requires_questionnaire, requires_mongomock
 from happi.backends.json_db import JSONBackend
 from happi.errors import DuplicateError, SearchError
 from happi import Client
-from happi.containers import Motor
+from happi.containers import Motor, Trigger
 
 
 @pytest.fixture(scope='function')
@@ -147,12 +147,13 @@ def test_json_initialize():
 
 @requires_questionnaire
 def test_qs_find(mockqsbackend):
-    assert len(mockqsbackend.find(beamline='TST', multiples=True)) == 6
+    assert len(mockqsbackend.find(beamline='TST', multiples=True)) == 8
     assert len(mockqsbackend.find(name='sam_r', multiples=True)) == 1
 
 
 @requires_questionnaire
 def test_qsbackend_with_client(mockqsbackend):
     c = Client(database=mockqsbackend)
-    assert len(c.all_devices) == 6
-    assert all([isinstance(d, Motor) for d in c.all_devices])
+    assert len(c.all_devices) == 8
+    assert all([isinstance(d, Motor) or isinstance(d, Trigger)
+                for d in c.all_devices])


### PR DESCRIPTION
## Description:
Gave happi questionnaire backend access to analog in/out and EVR control trigger PV's if entered in questionnaire, making this backend include any device in the questionnaire that is given a PV.
Does not include "Digitizers: Diodes et al." which are not given PV names

## Testing:
`import happi.backends.qs_db`
`qs_backend = happi.backends.qs_db.QSBackend('mfxlu3417')`
`print(qs_backend.db)`
` # Returns dictionary with entered PV's in quetsionnaire: https://pswww.slac.stanford.edu/questionnaire_slac/proposal_questionnaire/run17/LU34/#pcdssetup`