### PR TITLE
DEV: Ensure tests pass without mongomock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,31 @@ env:
 matrix:
   include:
       - python: 3.6
-        env: PCDS_CHANNEL=pcds-dev  
+        env:
+           - PCDS_CHANNEL=pcds-dev  
+           - USE_MONGO=1
       - python: 3.6
         env:
-            - NO_MONGO=1
-            - PCDS_CHANNEL=pcds-tag
+           - PCDS_CHANNEL=pcds-tag
+           - USE_MONGO=0
       - python: 3.6
         env:
            - BUILD_DOCS=1
            - PCDS_CHANNEL=pcds-tag
+           - USE_MONGO=1
       # Modification needed (https://github.com/travis-ci/travis-ci/issues/9815)
       - python: 3.7
         dist: xenial
         sudo: true
-        env: PCDS_CHANNEL=pcds-tag
+        env:
+           - PCDS_CHANNEL=pcds-tag
+           - USE_MONGO=1
       - python: 3.7
         dist: xenial
         sudo: true
-        env: PCDS_CHANNEL=pcds-dev
+        env:
+           - PCDS_CHANNEL=pcds-dev
+           - USE_MONGO=1
 
 install:
   - sudo apt-get update
@@ -48,7 +55,7 @@ install:
   # TODO: mongomock is not currently available via conda. Ultimately we should
   # probably build this ourselves, but until that day we resort to `pip`
   - |
-    if [[ "$NO_MONGO"=="1" ]]; then
+    if [[ "$USE_MONGO"=="1" ]]; then
       pip install mongomock
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
   # TODO: mongomock is not currently available via conda. Ultimately we should
   # probably build this ourselves, but until that day we resort to `pip`
   - |
-    if [[ "$USE_MONGO"=="1" ]]; then
+    if [[ "$USE_MONGO" == "1" ]]; then
       pip install mongomock
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
         env: PCDS_CHANNEL=pcds-dev  
       - python: 3.6
         env:
+            - NO_MONGO=1
+            - PCDS_CHANNEL=pcds-tag
+      - python: 3.6
+        env:
            - BUILD_DOCS=1
            - PCDS_CHANNEL=pcds-tag
       # Modification needed (https://github.com/travis-ci/travis-ci/issues/9815)
@@ -43,7 +47,11 @@ install:
   - source activate test-environment
   # TODO: mongomock is not currently available via conda. Ultimately we should
   # probably build this ourselves, but until that day we resort to `pip`
-  - pip install mongomock
+  - |
+    if [[ "$NO_MONGO"=="1" ]]; then
+      pip install mongomock
+    fi
+
 script:
   - coverage run run_tests.py
   - coverage report -m

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -86,17 +86,19 @@ def mockjsonclient(device_info):
 @pytest.fixture(scope='function')
 def mockmongoclient(device_info):
     with patch('happi.backends.mongo_db.MongoClient') as mock_mongo:
-        mc = MongoClient()
-        mc['test_db'].create_collection('test_collect')
-        mock_mongo.return_value = mc
-        # Client
-        backend = MongoBackend(db='test_db',
-                               collection='test_collect')
-        client = Client(database=backend)
-        # Insert a single device
-        client.backend._collection.insert_one(device_info)
-        return client
-
+        if has_mongomock:
+            mc = MongoClient()
+            mc['test_db'].create_collection('test_collect')
+            mock_mongo.return_value = mc
+            # Client
+            backend = MongoBackend(db='test_db',
+                                   collection='test_collect')
+            client = Client(database=backend)
+            # Insert a single device
+            client.backend._collection.insert_one(device_info)
+            return client
+        else:
+            return None
 
 @pytest.fixture(scope='function',
                 params=supported_backends)

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -100,6 +100,7 @@ def mockmongoclient(device_info):
         else:
             return None
 
+
 @pytest.fixture(scope='function',
                 params=supported_backends)
 def happi_client(request, mockmongoclient, mockjsonclient):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
More experienced @teddyrendahl knows that this too complicated a testing setup. A `pytest` fixture that has a variable number of parameter based on what you can import. 

That being said this is the one-line fix to make sure our tests still run w/o `mongomock` installed. The main reason I don't want to make this a testing requirement is it has no CONDA package and don't think the effort of packaging it ourselves is worth the time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified locally without `mongomock`