### PR TITLE
Container

### DIFF
--- a/docs/source/containers.rst
+++ b/docs/source/containers.rst
@@ -11,6 +11,11 @@ base that more specific devices will inherit from.
 .. autoclass:: happi.Device
    :members:
 
+These inherit from the most generic information that can be included:
+
+.. autoclass:: happi.HappiItem
+   :members:
+
 Containers
 ----------
 Each of the containers below share the attributes and entries of the generic

--- a/happi/__init__.py
+++ b/happi/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['Device', 'EntryInfo', 'Client', 'from_container',
-           'load_devices', 'cache']
+           'load_devices', 'cache', 'Container']
 import logging
 from .device import Container, Device, EntryInfo
 from .client import Client

--- a/happi/__init__.py
+++ b/happi/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['Device', 'EntryInfo', 'Client', 'from_container',
-           'load_devices', 'cache', 'Container']
+           'load_devices', 'cache', 'HappiItem']
 import logging
-from .device import Container, Device, EntryInfo
+from .device import HappiItem, Device, EntryInfo
 from .client import Client
 from .loader import from_container, load_devices, cache
 from ._version import get_versions

--- a/happi/__init__.py
+++ b/happi/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['Device', 'EntryInfo', 'Client', 'from_container',
            'load_devices', 'cache']
 import logging
-from .device import Device, EntryInfo
+from .device import Container, Device, EntryInfo
 from .client import Client
 from .loader import from_container, load_devices, cache
 from ._version import get_versions

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -19,7 +19,7 @@ class QSBackend(JSONBackend):
     This backend connects to the LCLS questionnaire and looks at devices with
     the key pattern pcds-{}-setup-{}-{}. These fields are then combined and
     turned into proper happi devices. The translation of table name to
-    ``happi.Container`` is determined by the :attr:`.device_translations`
+    ``happi.HappiItem`` is determined by the :attr:`.device_translations`
     dictionary. The beamline is determined by looking where the proposal was
     submitted.
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -61,7 +61,7 @@ def happi_cli(args):
 
         # Ensure we have an even number of search elements
         # Should always have key:value pairs
-        if len(args.search_criteria) % 2 is not 0:
+        if len(args.search_criteria) % 2 != 0:
             raise SearchError('Search criteria should be given as key '
                               'value pair\ni.e:\n'
                               'happi search beamline MFX stand DG1')

--- a/happi/client.py
+++ b/happi/client.py
@@ -39,7 +39,7 @@ class Client:
     """
     # Device information
     _client_attrs = ['_id', 'type', 'creation', 'last_edit']
-    _id = 'prefix'
+    _id = 'name'
     # Store device types seen by client
     device_types = {'Device': Device}
 

--- a/happi/device.py
+++ b/happi/device.py
@@ -206,13 +206,13 @@ class InfoMeta(type):
         return clsobj
 
 
-class Container(metaclass=InfoMeta):
+class HappiItem(metaclass=InfoMeta):
     """
-    The base Container object
+    The smallest description of an object that can be entered in ``happi``
 
     The class does not need to be intialized with any specific piece of
     information except a name, but all of the attributes listed by
-    :attr:`Container.info_names` can be used to assign values to
+    :attr:`HappiItem.info_names` can be used to assign values to
     :class:`.EntryInfo` upon initialization.  Pieces of information that are
     deemed mandatory by the class must be filled in before the device is loaded
     into the database. See :attr:`Device.mandatory_info` to see which
@@ -246,7 +246,7 @@ class Container(metaclass=InfoMeta):
     -------
     .. code ::
 
-        d = Container(name = 'my_device',         #Alias name for device
+        d = HappiItem(name = 'my_device',         #Alias name for device
                       note  = 'Example',          #Piece of arbitrary metadata
                      )
     """
@@ -358,7 +358,7 @@ class Container(metaclass=InfoMeta):
         return (self.prefix, self.name) == (other.prefix, other.name)
 
 
-class Device(Container):
+class Device(HappiItem):
     """
     A Generic Device
 
@@ -393,7 +393,7 @@ class Device(Container):
                           "LCLS Lightpath", enforce=bool, default=False)
     documentation = EntryInfo("Relevant documentation for the Device",
                               enforce=str)
-    args = copy.copy(Container.args)
+    args = copy.copy(HappiItem.args)
     args.default = ['{{prefix}}']
-    kwargs = copy.copy(Container.kwargs)
+    kwargs = copy.copy(HappiItem.kwargs)
     args.default = {'name': '{{name}}'}

--- a/happi/device.py
+++ b/happi/device.py
@@ -353,7 +353,7 @@ class HappiItem(metaclass=InfoMeta):
                                      self.name)
 
     def __eq__(self, other):
-        return (self.prefix, self.name) == (other.prefix, other.name)
+        return (self.post() == other.post())
 
 
 class Device(HappiItem):

--- a/happi/device.py
+++ b/happi/device.py
@@ -349,10 +349,8 @@ class HappiItem(metaclass=InfoMeta):
         raise NotImplementedError
 
     def __repr__(self):
-        return '{} {} (prefix={}, z={})'.format(self.__class__.__name__,
-                                                self.name,
-                                                self.prefix,
-                                                self.z)
+        return '{} (name={})'.format(self.__class__.__name__,
+                                     self.name)
 
     def __eq__(self, other):
         return (self.prefix, self.name) == (other.prefix, other.name)
@@ -397,3 +395,10 @@ class Device(HappiItem):
     args.default = ['{{prefix}}']
     kwargs = copy.copy(HappiItem.kwargs)
     args.default = {'name': '{{name}}'}
+
+    def __repr__(self):
+        return '{} (name={}, prefix={}, z={})'.format(
+                                    self.__class__.__name__,
+                                    self.name,
+                                    self.prefix,
+                                    self.z)

--- a/happi/device.py
+++ b/happi/device.py
@@ -1,3 +1,4 @@
+import copy
 import re
 import sys
 import logging
@@ -205,19 +206,20 @@ class InfoMeta(type):
         return clsobj
 
 
-class Device(metaclass=InfoMeta):
+class Container(metaclass=InfoMeta):
     """
-    A Generic Device Container
+    The base Container object
 
     The class does not need to be intialized with any specific piece of
-    information, but all of the attributes listed by :attr:`Device.info_names`
-    can be used to assign values to :class:`.EntryInfo` upon initialization.
-    Pieces of information that are deemed mandatory by the class must be filled
-    in before the device is loaded into the database. See
-    :attr:`Device.mandatory_info` to see which attributes are neccesary.
+    information except a name, but all of the attributes listed by
+    :attr:`Container.info_names` can be used to assign values to
+    :class:`.EntryInfo` upon initialization.  Pieces of information that are
+    deemed mandatory by the class must be filled in before the device is loaded
+    into the database. See :attr:`Device.mandatory_info` to see which
+    attributes are neccesary.
 
-    Additional metadata can be given to the device in the form of keywords
-    on initialization, this information is kept in the :attr:`.extraneous`
+    Additional metadata can be given to the device in the form of keywords on
+    initialization, this information is kept in the :attr:`.extraneous`
     attribute, and will be saved in to the database as long as it does not
     clash with an existing piece of metadata that the client uses to organize
     devices.
@@ -244,50 +246,22 @@ class Device(metaclass=InfoMeta):
     -------
     .. code ::
 
-        d = Device(name = 'my_device',         #Alias name for device
-                   prefix  = 'CXI:DG2:DEV:01', #Base PV for device
-                   note  = 'Example',          #Piece of arbitrary metadata
-                  )
+        d = Container(name = 'my_device',         #Alias name for device
+                      note  = 'Example',          #Piece of arbitrary metadata
+                     )
     """
     name = EntryInfo('Shorthand name for the device',
                      optional=False, enforce=str)
-    prefix = EntryInfo('A base PV for all related records',
-                       optional=False, enforce=str)
-    beamline = EntryInfo('Section of beamline the device belongs',
-                         optional=False, enforce=str)
-    z = EntryInfo('Beamline position of the device',
-                  enforce=float, default=-1.0)
     device_class = EntryInfo("Python class that represents the Device",
                              enforce=str)
     args = EntryInfo("Arguments to pass to device_class",
-                     enforce=list, default=['{{prefix}}'])
+                     enforce=list, default=[])
     kwargs = EntryInfo("Keyword arguments to pass to device_class",
-                       enforce=dict, default={'name': '{{name}}'})
-    stand = EntryInfo('Acronym for stand, must be three alphanumeric '
-                      'characters', enforce=re.compile(r'[A-Z0-9]{3}$'))
-    detailed_screen = EntryInfo('The absolute path to the main control screen',
-                                enforce=str)
-    embedded_screen = EntryInfo('The absolute path to the '
-                                'embedded control screen',
-                                enforce=str)
-    engineering_screen = EntryInfo('The absolute path to '
-                                   'the engineering control screen',
-                                   enforce=str)
+                       enforce=dict, default={})
     active = EntryInfo('Whether the device is actively deployed',
                        enforce=bool, default=True)
-    system = EntryInfo('The system the device is involved with, i.e '
-                       'Vacuum, Timing e.t.c',
-                       enforce=str)
-    macros = EntryInfo("The EDM macro string asscociated with the "
-                       "with the device. By using a jinja2 template, "
-                       "this can reference other EntryInfo keywords.",
-                       enforce=str)
     parent = EntryInfo('If the device is a component of another, '
                        'enter the name', enforce=str)
-    lightpath = EntryInfo("If the device should be included in the "
-                          "LCLS Lightpath", enforce=bool, default=False)
-    documentation = EntryInfo("Relevant documentation for the Device",
-                              enforce=str)
 
     def __init__(self, **kwargs):
         # Load given information into device class
@@ -382,3 +356,44 @@ class Device(metaclass=InfoMeta):
 
     def __eq__(self, other):
         return (self.prefix, self.name) == (other.prefix, other.name)
+
+
+class Device(Container):
+    """
+    A Generic Device
+
+    Meant for any object will be loaded to represent a physical object in the
+    controls system. Contains information on the physical location of the
+    device as well as various
+    """
+    prefix = EntryInfo('A base PV for all related records',
+                       optional=False, enforce=str)
+    beamline = EntryInfo('Section of beamline the device belongs',
+                         optional=False, enforce=str)
+    z = EntryInfo('Beamline position of the device',
+                  enforce=float, default=-1.0)
+    stand = EntryInfo('Acronym for stand, must be three alphanumeric '
+                      'characters', enforce=re.compile(r'[A-Z0-9]{3}$'))
+    detailed_screen = EntryInfo('The absolute path to the main control screen',
+                                enforce=str)
+    embedded_screen = EntryInfo('The absolute path to the '
+                                'embedded control screen',
+                                enforce=str)
+    engineering_screen = EntryInfo('The absolute path to '
+                                   'the engineering control screen',
+                                   enforce=str)
+    system = EntryInfo('The system the device is involved with, i.e '
+                       'Vacuum, Timing e.t.c',
+                       enforce=str)
+    macros = EntryInfo("The EDM macro string asscociated with the "
+                       "with the device. By using a jinja2 template, "
+                       "this can reference other EntryInfo keywords.",
+                       enforce=str)
+    lightpath = EntryInfo("If the device should be included in the "
+                          "LCLS Lightpath", enforce=bool, default=False)
+    documentation = EntryInfo("Relevant documentation for the Device",
+                              enforce=str)
+    args = copy.copy(Container.args)
+    args.default = ['{{prefix}}']
+    kwargs = copy.copy(Container.kwargs)
+    args.default = {'name': '{{name}}'}

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -95,7 +95,7 @@ def from_container(device, attach_md=True, use_cache=True):
         return the same object. This prevents unnecessary EPICS connections
         from being initialized in the same process. If a new object is
         needed, set `use_cache` to False and a new object will be created,
-        overriding the current cached object. An object with matching prefix
+        overriding the current cached object. An object with matching name
         and differing metadata will always return a new instantiation of the
         device.
 
@@ -104,8 +104,8 @@ def from_container(device, attach_md=True, use_cache=True):
     obj : happi.Device.device_class
     """
     # Return a cached version of the device if present and not forced
-    if use_cache and device.prefix in cache:
-        cached_device = cache[device.prefix]
+    if use_cache and device.name in cache:
+        cached_device = cache[device.name]
         # If the metadata has not been modified or we can't review it.
         # Return the cached object
         if not hasattr(cached_device, 'md') or cached_device.md == device:
@@ -115,7 +115,7 @@ def from_container(device, attach_md=True, use_cache=True):
         else:
             logger.warning("Device %s has already been loaded, but the "
                            "database information has been modified. "
-                           "Reloading ...", device.prefix)
+                           "Reloading ...", device.name)
 
     # Find the class and module of the container.
     if not device.device_class:
@@ -157,7 +157,7 @@ def from_container(device, attach_md=True, use_cache=True):
             logger.warning("Unable to attach metadata dictionary to device")
 
     # Store a copy of the device in the cache
-    cache[device.prefix] = obj
+    cache[device.name] = obj
     return obj
 
 

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -108,8 +108,8 @@ def from_container(device, attach_md=True, use_cache=True):
         cached_device = cache[device.name]
         # If the metadata has not been modified or we can't review it.
         # Return the cached object
-        if not hasattr(cached_device, 'md') or cached_device.md == device:
-            logger.debug("Loading %s from cache ...", device.prefix)
+        if hasattr(cached_device, 'md') and cached_device.md == device:
+            logger.debug("Loading %s from cache ...", device.name)
             return cached_device
         # Otherwise reload
         else:

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -41,7 +41,7 @@ requires_questionnaire = pytest.mark.skipif(not has_qs_cli,
 def device_info():
     return {'name': 'alias',
             'z': 400,
-            '_id': 'BASE:PV',
+            '_id': 'alias',
             'prefix': 'BASE:PV',
             'beamline': 'LCLS',
             'type': 'Device',
@@ -61,7 +61,7 @@ def valve_info():
     return {'name': 'name',
             'z': 300,
             'prefix': 'BASE:VGC:PV',
-            '_id': 'BASE:VGC:PV',
+            '_id': 'name',
             'beamline': 'LCLS',
             'mps': 'MPS:VGC:PV'}
 
@@ -76,7 +76,7 @@ def valve(valve_info):
 def mockjsonclient(device_info):
     # Write underlying database
     with open('testing.json', 'w+') as handle:
-        simplejson.dump({device_info['prefix']: device_info},
+        simplejson.dump({device_info['name']: device_info},
                         handle)
     # Return handle name
     db = JSONBackend('testing.json')

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -21,7 +21,7 @@ def mockmongo(mockmongoclient):
 def mockjson(device_info, valve_info):
     # Write underlying database
     with open('testing.json', 'w+') as handle:
-        simplejson.dump({device_info['prefix']: device_info},
+        simplejson.dump({device_info['_id']: device_info},
                         handle)
     # Return handle name
     yield JSONBackend('testing.json')
@@ -59,20 +59,20 @@ def test_mongo_find(valve_info, device_info, mockmongo):
 def test_mongo_save(mockmongo, device_info, valve_info):
     # Duplicate device
     with pytest.raises(DuplicateError):
-        mockmongo.save(device_info['prefix'], device_info, insert=True)
+        mockmongo.save(device_info[Client._id], device_info, insert=True)
 
     # Device not found
     with pytest.raises(SearchError):
-        mockmongo.save(valve_info['prefix'], valve_info, insert=False)
+        mockmongo.save(valve_info[Client._id], valve_info, insert=False)
 
     # Add to database
-    mockmongo.save(valve_info['prefix'], valve_info, insert=True)
+    mockmongo.save(valve_info[Client._id], valve_info, insert=True)
     assert mockmongo._collection.find_one(valve_info) == valve_info
 
 
 @requires_mongomock
 def test_mongo_delete(mockmongo, device_info):
-    mockmongo.delete(device_info['prefix'])
+    mockmongo.delete(device_info[Client._id])
     assert mockmongo._collection.find_one(device_info) is None
 
 
@@ -80,8 +80,8 @@ def test_json_find(valve_info, device_info, mockjson):
     mm = mockjson
     # Write underlying database
     with open(mm.path, 'w+') as handle:
-        simplejson.dump({valve_info['prefix']: valve_info,
-                         device_info['prefix']: device_info},
+        simplejson.dump({valve_info['_id']: valve_info,
+                         device_info['_id']: device_info},
                         handle)
     # No single device expected
     assert mm.find(beamline='BLERG', multiples=False) == []
@@ -105,21 +105,21 @@ def test_json_find(valve_info, device_info, mockjson):
 
 
 def test_json_delete(mockjson, device_info):
-    mockjson.delete(device_info['prefix'])
+    mockjson.delete(device_info[Client._id])
     assert device_info not in mockjson.all_devices
 
 
 def test_json_save(mockjson, device_info, valve_info):
     # Duplicate device
     with pytest.raises(DuplicateError):
-        mockjson.save(device_info['prefix'], device_info, insert=True)
+        mockjson.save(device_info[Client._id], device_info, insert=True)
 
     # Device not found
     with pytest.raises(SearchError):
-        mockjson.save(valve_info['prefix'], valve_info, insert=False)
+        mockjson.save(valve_info[Client._id], valve_info, insert=False)
 
     # Add to database
-    mockjson.save(valve_info['prefix'], valve_info, insert=True)
+    mockjson.save(valve_info[Client._id], valve_info, insert=True)
     assert valve_info in mockjson.all_devices
 
 

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -93,16 +93,11 @@ def test_all_devices(happi_client, device):
     assert happi_client.all_devices == [device]
 
 
-def test_add_device(happi_client, valve, device, valve_info):
+def test_add_device(happi_client, valve):
     happi_client.add_device(valve)
-    doc = happi_client.backend.find(multiples=False, **valve_info)
-    assert valve.prefix == doc['prefix']
-    assert valve.name == doc['name']
-    assert valve.z == doc['z']
-    assert valve.beamline == doc['beamline']
     # No duplicates
     with pytest.raises(DuplicateError):
-        happi_client.add_device(device)
+        happi_client.add_device(valve)
     # No incompletes
     d = Device()
     with pytest.raises(EntryError):
@@ -145,7 +140,7 @@ def test_validate(happi_client):
     # No bad devices
     assert happi_client.validate() == list()
     # A single bad device
-    happi_client.backend.save('_id', {'prefix': 'bad'}, insert=True)
+    happi_client.backend.save('_id', {happi_client._id: 'bad'}, insert=True)
     assert happi_client.validate() == ['bad']
 
 

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -43,7 +43,7 @@ def test_caching():
                    device_class='types.SimpleNamespace', args=list(), days=10,
                    kwargs={'days': '{{days}}', 'seconds': 30})
     td = from_container(d)
-    assert d.prefix in cache
+    assert d.name in cache
     assert id(td) == id(from_container(d))
     assert id(td) != id(from_container(d, use_cache=False))
     # Modify md and check we see a reload

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -54,7 +54,7 @@ def test_caching():
                    device_class='datetime.timedelta', args=list(), days=10,
                    kwargs={'days': '{{days}}', 'seconds': 30})
     td = from_container(d)
-    assert id(td) == id(from_container(d))
+    assert id(td) != id(from_container(d))
     assert id(td) != id(from_container(d, use_cache=False))
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
For a while it has bothered me that base `happi.Device` makes a lot of assumptions about item you want to put in the database. I think location information should be required for physical devices but it is pretty unwieldy if you are just setting up a little simulation and want to fill a database with `ophyd.sim.SynAxis` objects.  

This PR creates a base `Container` object which has the bare minimum amount of `EntryInfo`. This is a good starting point for any external collaborators who want to use `happi` but don't plan on using any of our device types. One consequence of this is that we no longer enforce that `prefix` exists (see simulation) on `Container`. Therefore we need to retrain our database to use `name` as the unique enforceable key. This is still compatible with databases created with older versions of `happi` 

###### API Thoughts
In the docstrings I tried to replace all mentions of `Device` with `Container` but methods are still called `find_device` e.t.c. I like the new `Container` name, it creates a clear separation between the configuration information (`Container`) and the actual `ophyd.Device`. I think calling these the same thing is probably confusing for new folks.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #83 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Existing test suite passes, simply had to change a few places where we assumed what that `_id` tag was.
* Successfully loaded older happi database

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
TBD