### PR TITLE
ENH: Happi-aware QTreeView

### DIFF
--- a/examples/qt/treeview.py
+++ b/examples/qt/treeview.py
@@ -1,0 +1,59 @@
+import pathlib
+from qtpy import QtWidgets
+
+import happi
+import happi.qt
+
+
+class HappiDeviceExplorer(QtWidgets.QFrame):
+    _GROUP_KEYS = {'Name': 'name',
+                   'Function': 'functional_group',
+                   'Location': 'location_group'}
+
+    def __init__(self, parent=None):
+        super(HappiDeviceExplorer, self).__init__(parent=parent)
+
+        self.view = happi.qt.model.HappiDeviceTreeView(self)
+        self.view.groups = [v for _, v in self._GROUP_KEYS.items()]
+
+        self.group_label = QtWidgets.QLabel("&Group By")
+        self.group_combo = QtWidgets.QComboBox()
+        self.group_label.setBuddy(self.group_combo)
+
+        for display, val in self._GROUP_KEYS.items():
+            self.group_combo.addItem(display, val)
+
+        def set_group(_):
+            key = self.group_combo.currentData()
+            self.view.group_by(key)
+
+        self.group_combo.currentIndexChanged.connect(set_group)
+
+        self.filter_label = QtWidgets.QLabel("&Filter")
+        self.filter_edit = QtWidgets.QLineEdit()
+        self.filter_label.setBuddy(self.filter_edit)
+
+        def set_filter(text):
+            self.view.proxy_model.setFilterRegExp(text)
+
+        self.filter_edit.textEdited.connect(set_filter)
+
+        self.setLayout(QtWidgets.QGridLayout())
+        self.layout().addWidget(self.filter_label, 1, 0)
+        self.layout().addWidget(self.filter_edit, 1, 1)
+        self.layout().addWidget(self.group_label, 2, 0)
+        self.layout().addWidget(self.group_combo, 2, 1)
+        self.layout().addWidget(self.view, 3, 0, 1, 2)
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication([])
+    file_path = pathlib.Path(__file__).resolve()
+    db_path = file_path.parent.parent / "db.json"
+    cli = happi.Client(path=db_path)
+    w = HappiDeviceExplorer()
+    w.view.client = cli
+    w.view.search(beamline="DEMO_BEAMLINE")
+    w.show()
+
+    app.exec_()

--- a/examples/qt/treeview.py
+++ b/examples/qt/treeview.py
@@ -1,5 +1,5 @@
 import pathlib
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 import happi
 import happi.qt
@@ -38,18 +38,55 @@ class HappiDeviceExplorer(QtWidgets.QFrame):
 
         self.filter_edit.textEdited.connect(set_filter)
 
-        self.setLayout(QtWidgets.QGridLayout())
-        self.layout().addWidget(self.filter_label, 1, 0)
-        self.layout().addWidget(self.filter_edit, 1, 1)
-        self.layout().addWidget(self.group_label, 2, 0)
-        self.layout().addWidget(self.group_combo, 2, 1)
-        self.layout().addWidget(self.view, 3, 0, 1, 2)
+        self.setLayout(QtWidgets.QVBoxLayout())
+
+        self.filter_frame = QtWidgets.QFrame()
+        self.filter_frame.setLayout(QtWidgets.QGridLayout())
+
+        self.filter_frame.layout().addWidget(self.filter_label, 1, 0)
+        self.filter_frame.layout().addWidget(self.filter_edit, 1, 1)
+        self.filter_frame.layout().addWidget(self.group_label, 2, 0)
+        self.filter_frame.layout().addWidget(self.group_combo, 2, 1)
+
+        self.splitter = QtWidgets.QSplitter()
+        self.splitter.setOrientation(QtCore.Qt.Vertical)
+
+        self.splitter.addWidget(self.filter_frame)
+        self.splitter.addWidget(self.view)
+        self.splitter.setSizes([0, 1])
+        self.splitter.setHandleWidth(10)
+        self.splitter.setStretchFactor(0, 0)
+        self.splitter.setStretchFactor(1, 1)
+
+        self.splitter.setCollapsible(1, False)
+
+        handle = self.splitter.handle(1)
+        layout = QtWidgets.QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        button = QtWidgets.QToolButton(handle)
+        button.setArrowType(QtCore.Qt.DownArrow)
+        button.clicked.connect(lambda: self.handle_splitter_button(True))
+        layout.addWidget(button)
+        button = QtWidgets.QToolButton(handle)
+        button.setArrowType(QtCore.Qt.UpArrow)
+        button.clicked.connect(lambda: self.handle_splitter_button(False))
+        layout.addWidget(button)
+        handle.setLayout(layout)
+
+        self.layout().addWidget(self.splitter)
+
+    def handle_splitter_button(self, down=True):
+        if down:
+            self.splitter.setSizes([1, 1])
+        else:
+            self.splitter.setSizes([0, 1])
 
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication([])
     file_path = pathlib.Path(__file__).resolve()
     db_path = file_path.parent.parent / "db.json"
+
     cli = happi.Client(path=db_path)
     w = HappiDeviceExplorer()
     w.view.client = cli

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -199,10 +199,15 @@ class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
             root = QtGui.QStandardItem(key_value)
             # Disable edit
             root.setFlags(root.flags() & ~QtCore.Qt.ItemIsEditable)
-            # Pack the entries into the root
-            root.setData(entries)
-            for entry in entries:
-                root.appendRow(self.create_item(entry))
+
+            if len(entries) == 1 and entries[0].name == key_value:
+                root.setData(entries[0])
+            else:
+                #Pack the entries into the root
+                root.setData(entries)
+
+                for entry in entries:
+                    root.appendRow(self.create_item(entry))
             model.appendRow(root)
 
         self._models[field] = model

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -1,35 +1,20 @@
+import logging
+import collections
 from qtpy import QtCore, QtGui, QtWidgets
 
+from ..utils import get_happi_entry_value
 
-class HappiDeviceListView(QtWidgets.QListView):
+logger = logging.getLogger(__name__)
+
+
+class HappiViewMixin(object):
     """
-    QListView which displays Happi entries.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget
-
-    client : Client
-        A happi.Client instance
-
-    kwargs : dict
-        Additional arguments to be passed to the QListView constructor.
+    Base class to be used for View widgets
     """
-    def __init__(self, parent=None, client=None, **kwargs):
-        super().__init__(parent=parent, **kwargs)
+    def __init__(self, client=None, **kwargs):
+        super().__init__(**kwargs)
         self._client = client
-        self.model = QtGui.QStandardItemModel()
-        self.model.setHorizontalHeaderLabels(["Devices"])
-
-        self.proxy_model = QtCore.QSortFilterProxyModel()
-        self.proxy_model.setFilterKeyColumn(-1)
-        self.proxy_model.setDynamicSortFilter(True)
-        self.proxy_model.setSourceModel(self.model)
-        self.setModel(self.proxy_model)
-
-        self.models = {}
-        self._happi_entries = []
+        self._entries = []
 
     @property
     def client(self):
@@ -46,6 +31,16 @@ class HappiDeviceListView(QtWidgets.QListView):
     def client(self, client):
         self._client = client
 
+    def entries(self):
+        """
+        List of search results.
+
+        Returns
+        -------
+        list
+        """
+        return self._entries
+
     def search(self, *args, **kwargs):
         """
         Performs a search into the Happi database and populate the model
@@ -53,22 +48,59 @@ class HappiDeviceListView(QtWidgets.QListView):
 
         args and kwargs are sent directly to happi.Client.search method.
         """
-        self._happi_entries = self._client.search(*args, **kwargs)
+        self._entries = self._client.search(*args, **kwargs)
+
+    @staticmethod
+    def create_item(entry):
+        itm = QtGui.QStandardItem(entry.name)
+        itm.setData(entry)
+        itm.setFlags(itm.flags() & ~QtCore.Qt.ItemIsEditable)
+        return itm
+
+
+class HappiDeviceListView(QtWidgets.QListView, HappiViewMixin):
+    """
+    QListView which displays Happi entries.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget
+
+    client : Client
+        A happi.Client instance
+
+    kwargs : dict
+        Additional arguments to be passed to the QListView constructor.
+    """
+    def __init__(self, parent=None, client=None, **kwargs):
+        super().__init__(parent=parent, client=client, **kwargs)
+        self.model = QtGui.QStandardItemModel()
+        self.model.setHorizontalHeaderLabels(["Devices"])
+
+        self.proxy_model = QtCore.QSortFilterProxyModel()
+        self.proxy_model.setFilterKeyColumn(-1)
+        self.proxy_model.setDynamicSortFilter(True)
+        self.proxy_model.setSourceModel(self.model)
+        self.setModel(self.proxy_model)
+
+    def search(self, *args, **kwargs):
+        """
+        Performs a search into the Happi database and populate the model
+        with the new data.
+
+        args and kwargs are sent directly to happi.Client.search method.
+        """
+        super().search(*args, **kwargs)
         self._update_data()
 
     def _update_data(self):
         """
         Update the model with new data from the search.
         """
-        def create_item(entry):
-            itm = QtGui.QStandardItem(entry.name)
-            itm.setData(entry)
-            itm.setFlags(itm.flags() & ~QtCore.Qt.ItemIsEditable)
-            return itm
-
-        if not self._happi_entries:
+        if not self.entries():
             return
-        items = [create_item(entry) for entry in self._happi_entries]
+        items = [self.create_item(entry) for entry in self.entries()]
 
         self.model.clear()
 
@@ -76,3 +108,111 @@ class HappiDeviceListView(QtWidgets.QListView):
             self.model.setItem(row, itm)
         self.proxy_model.setSourceModel(self.model)
         self.proxy_model.sort(0, QtCore.Qt.AscendingOrder)
+
+
+class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
+    """
+    QListView which displays Happi entries.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget
+
+    client : Client
+        A happi.Client instance
+
+    kwargs : dict
+        Additional arguments to be passed to the QListView constructor.
+    """
+    def __init__(self, parent=None, client=None, **kwargs):
+        super().__init__(parent=parent, client=client, **kwargs)
+        self._models = dict()
+        self._groups = []
+        self._active_group = ""
+
+        self.proxy_model = QtCore.QSortFilterProxyModel()
+        self.proxy_model.setFilterKeyColumn(-1)
+        self.proxy_model.setRecursiveFilteringEnabled(True)
+        self.proxy_model.setDynamicSortFilter(True)
+        self.setModel(self.proxy_model)
+
+    def search(self, *args, **kwargs):
+        """
+        Performs a search into the Happi database and populate the model
+        with the new data.
+
+        args and kwargs are sent directly to happi.Client.search method.
+        """
+        super().search(*args, **kwargs)
+        self._update_data()
+
+    def group_by(self, field, force=False):
+        if field and (self._active_group != field or force):
+            self._active_group = field
+            model = self._models.get(field, None)
+            if not model:
+                logger.error('Group model for %s does not exist. Update the '
+                             'groups information first.')
+            self.proxy_model.setSourceModel(model)
+
+    @property
+    def groups(self):
+        """
+        List of fields to be used when grouping Happi entries.
+
+        Returns
+        -------
+        list
+        """
+        return self._groups
+
+    @groups.setter
+    def groups(self, groups):
+        if self._groups != groups and groups:
+            self._groups = groups
+            if not self._active_group:
+                self._active_group = groups[0]
+            self._update_data()
+
+    def _create_group_model(self, field, force=False):
+        if field in self._models and not force:
+            return
+
+        model = QtGui.QStandardItemModel()
+        model.setHorizontalHeaderLabels(["Devices"])
+
+        entry_group = collections.defaultdict(list)
+
+        for entry in self.entries():
+            try:
+                field_val = get_happi_entry_value(entry, field)
+                entry_group[field_val].append(entry)
+            except ValueError:
+                logger.exception(
+                    'Could not retrieve value for field %s at entry %s',
+                    field, entry
+                )
+
+        for idx, (key_value, entries) in enumerate(entry_group.items()):
+            root = QtGui.QStandardItem(key_value)
+            # Disable edit
+            root.setFlags(root.flags() & ~QtCore.Qt.ItemIsEditable)
+            # Pack the entries into the root
+            root.setData(entries)
+            for entry in entries:
+                root.appendRow(self.create_item(entry))
+            model.appendRow(root)
+
+        self._models[field] = model
+        return model
+
+    def _update_data(self):
+        """
+        Update the model with new data from the search.
+        """
+        for field in self._groups:
+            if not field:
+                return
+            self._create_group_model(field, force=True)
+        self.group_by(self._active_group, force=True)

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -203,7 +203,7 @@ class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
             if len(entries) == 1 and entries[0].name == key_value:
                 root.setData(entries[0])
             else:
-                #Pack the entries into the root
+                # Pack the entries into the root
                 root.setData(entries)
 
                 for entry in entries:

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -127,6 +127,7 @@ class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
     """
     def __init__(self, parent=None, client=None, **kwargs):
         super().__init__(parent=parent, client=client, **kwargs)
+        self.setSortingEnabled(True)
         self._models = dict()
         self._groups = []
         self._active_group = ""

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -8,3 +8,15 @@ def create_alias(name):
     Clean an alias to be an acceptable Python variable
     """
     return name.replace(' ', '_').replace('.', '_').lower()
+
+
+def get_happi_entry_value(entry, key, search_extraneous=True):
+    extraneous = entry.extraneous
+    value = getattr(entry, key, None)
+    if value is None and search_extraneous:
+        # Try to look at extraneous
+        value = extraneous.get(key, None)
+
+    if not value:
+        raise ValueError('Invalid Key for Device.')
+    return value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add a Happi-aware QTreeView that can display the results of a Happi search.

## Motivation and Context
To allow UI projects to better leverage Happi in an uniform way.
This will be used for LUCID and other projects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally via example shipped with this PR

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet documented.

## Screenshots (if appropriate):
![treeview](https://user-images.githubusercontent.com/8185425/76461325-eff3c600-639c-11ea-928a-7f9638d54043.gif)


## Issues
There is this little detail demonstrated at the last piece of the GIF above in which if we filter and no child match the filter but the parent does, only the parent is displayed.
That is not a show stopper but in order to fix that we would need to subclass the QSortFilterProxyModel and tweak the `filterAcceptsRow` method. I'm not sure how much effort we should put into something like this. Up for discussion.