### PR TITLE
MNT: Multi backend

### DIFF
--- a/happi/backends/__init__.py
+++ b/happi/backends/__init__.py
@@ -1,24 +1,42 @@
-__all__ = ['backend']
+__all__ = ['backend', 'BACKENDS', 'DEFAULT_BACKEND']
 import os
-# Check to see if the user has specified a specific backend
-# as an environment variable. Import this as the standard
-# backend for other places in the module. A user can always
-# override this by explicitly importing the backend
-_backend = os.environ.get("HAPPI_BACKEND", 'json').lower()
-
 
 def _get_backend(backend):
     if backend == 'mongodb':
         from .mongo_db import MongoBackend
         return MongoBackend
-    elif backend == 'json':
+    if backend == 'json':
         from .json_db import JSONBackend
         return JSONBackend
-    else:
-        raise ImportError("Improper specification of happi backend."
-                          "Check `$HAPPI_BACKEND` environment variable.")
+    raise ValueError(f'Unknown backend {backend!r}')
 
 
-backend = _get_backend(_backend)
+def _get_backends():
+    # A hook for entrypoints or something similar later
+    backends = {}
+    try:
+        backends['json'] = _get_backend('json')
+    except ImportError as ex:
+        logger.warning('JSON backend unavailable: %s', ex)
 
-del _backend
+    try:
+        backends['mongodb'] = _get_backend('mongodb')
+    except ImportError as ex:
+        logger.warning('MongoDB backend unavailable: %s', ex)
+
+    return backends
+
+
+BACKENDS = _get_backends()
+try:
+    # Check to see if the user has specified a specific backend as an
+    # environment variable. Import this as the standard backend for other
+    # places in the module. A user can always override this by explicitly
+    # importing the backend
+    DEFAULT_BACKEND = BACKENDS[os.environ.get("HAPPI_BACKEND", 'json').lower()]
+except KeyError:
+    raise ImportError("Improper specification of happi backend. "
+                      "Check the `$HAPPI_BACKEND` environment variable.")
+
+# back-compatibility
+backend = DEFAULT_BACKEND

--- a/happi/backends/__init__.py
+++ b/happi/backends/__init__.py
@@ -1,5 +1,10 @@
 __all__ = ['backend', 'BACKENDS', 'DEFAULT_BACKEND']
 import os
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 def _get_backend(backend):
     if backend == 'mongodb':

--- a/happi/backends/__init__.py
+++ b/happi/backends/__init__.py
@@ -8,6 +8,9 @@ def _get_backend(backend):
     if backend == 'json':
         from .json_db import JSONBackend
         return JSONBackend
+    if backend == 'qs':
+        from .qs_db import QSBackend
+        return QSBackend
     raise ValueError(f'Unknown backend {backend!r}')
 
 
@@ -23,6 +26,11 @@ def _get_backends():
         backends['mongodb'] = _get_backend('mongodb')
     except ImportError as ex:
         logger.warning('MongoDB backend unavailable: %s', ex)
+
+    try:
+        backends['qs'] = _get_backend('qs')
+    except ImportError as ex:
+        logger.warning('Questionnaire backend unavailable: %s', ex)
 
     return backends
 

--- a/happi/client.py
+++ b/happi/client.py
@@ -7,7 +7,7 @@ import sys
 import time as ttime
 
 from . import containers
-from .backends import _get_backend, DEFAULT_BACKEND
+from .backends import BACKENDS, DEFAULT_BACKEND
 from .backends.core import _Backend
 from .device import Device, HappiItem
 from .errors import DatabaseError, EntryError, SearchError
@@ -510,7 +510,12 @@ class Client:
         # If a backend is specified use it, otherwise default
         if 'backend' in db_kwargs:
             db_str = db_kwargs.pop('backend')
-            backend = _get_backend(db_str)
+            try:
+                backend = BACKENDS[db_str]
+            except KeyError:
+                raise RuntimeError(
+                    f'Happi backend {db_str!r} unavailable'
+                ) from None
         else:
             backend = DEFAULT_BACKEND
 


### PR DESCRIPTION
I set out to further understand happi internals and ~close~ #24, but in writing the commits here, I think there may not be anything to fix.

The couple things here add a bit of clarity and also allow access to all loaded backends - which could potentially be an entrypoints hook at some point, I suppose. So, this doesn't have to be merged 🤷‍♂ 

I thought we were going to have a single database for beamline devices, at least. Other uses of happi (which do not yet exist) should load a different configuration that only they are aware of?

Perhaps @ZLLentz could further clarify and decide whether or not we can ~close~ #24.