### PR TITLE
ENH: happi.client.Client.search() refactor

### DIFF
--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -177,8 +177,8 @@ class JSONBackend(_Backend):
             Find a single result or all results matching the provided
             information
 
-        kwargs :
-            Requested information
+        **kwargs
+            Requested information, all of which must match
         """
         def comparison(name, doc):
             # Find devices matching kwargs
@@ -209,7 +209,7 @@ class JSONBackend(_Backend):
             Find a single result or all results matching the provided
             information
 
-        kwargs :
+        **kwargs
             Requested information, where the values are regular expressions.
         """
         if _id is None:

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -5,6 +5,7 @@ import contextlib
 import os
 import os.path
 import logging
+import math
 import re
 
 import simplejson as json
@@ -176,6 +177,31 @@ class JSONBackend(_Backend):
         def comparison(name, doc):
             return all(value == doc[key]
                        for key, value in to_match.items())
+
+        yield from self._iterative_compare(comparison)
+
+    def find_range(self, key, *, start, stop=None, to_match):
+        """
+        Find an instance or instances that matches the search criteria,
+        using regular expressions.
+
+        Parameters
+        ----------
+        to_match : dict
+            Requested information, where the values are regular expressions.
+        """
+        def comparison(name, doc):
+            if all(value == doc[k] for k, value in to_match.items()):
+                value = doc.get(key)
+                try:
+                    return start <= value < stop
+                except Exception:
+                    ...
+
+        if stop is None:
+            stop = math.inf
+        if start >= stop:
+            raise ValueError(f"Invalid range: {start} >= {stop}")
 
         yield from self._iterative_compare(comparison)
 

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -262,4 +262,6 @@ class JSONBackend(_Backend):
             try:
                 db.pop(_id)
             except KeyError:
-                logger.warning("Device %s not found in database", _id)
+                raise SearchError(
+                    f'ID not found in database: {_id!r}'
+                ) from None

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -182,13 +182,22 @@ class JSONBackend(_Backend):
 
     def find_range(self, key, *, start, stop=None, to_match):
         """
-        Find an instance or instances that matches the search criteria,
-        using regular expressions.
+        Find an instance or instances that matches the search criteria, such
+        that ``start <= entry[key] < stop``.
 
         Parameters
         ----------
+        key : str
+            The database key to search
+
+        start : int or float
+            Inclusive minimum value to filter ``key`` on
+
+        end : float, optional
+            Exclusive maximum value to filter ``key`` on
+
         to_match : dict
-            Requested information, where the values are regular expressions.
+            Requested information, where the values must match exactly
         """
         def comparison(name, doc):
             if all(value == doc[k] for k, value in to_match.items()):
@@ -198,6 +207,9 @@ class JSONBackend(_Backend):
                 except Exception:
                     ...
 
+        if key in to_match:
+            raise ValueError('Cannot specify the same key in `to_match` as '
+                             'the key for the range.')
         if stop is None:
             stop = math.inf
         if start >= stop:

--- a/happi/backends/mongo_db.py
+++ b/happi/backends/mongo_db.py
@@ -86,6 +86,18 @@ class MongoBackend(_Backend):
         """
         yield from self._collection.find(device_info)
 
+    def get_by_id(self, _id):
+        """
+        Get a device by ID if it exists, or None
+
+        Parameters
+        ----------
+        _id : str
+            The device ID
+        """
+        for item in self._collection.find({'_id': _id}):
+            return item
+
     def find_regex(self, to_match, *, flags=re.IGNORECASE):
         """
         Yield all instances that match the given search criteria

--- a/happi/backends/mongo_db.py
+++ b/happi/backends/mongo_db.py
@@ -72,30 +72,16 @@ class MongoBackend(_Backend):
         """
         return self._collection.find()
 
-    def find(self, multiples=False, **kwargs):
+    def find(self, device_info):
         """
-        Find an instance or instances that matches the search criteria
+        Yield all instances that match the given search criteria
 
         Parameters
         ----------
-        multiples : bool
-            Find a single result or all results matching the provided
-            information
-
-        kwargs :
+        device_info : dict
             Requested information
         """
-        # Find all matches
-        cur = list(self._collection.find(kwargs))
-        # Only return a single device if requested
-        if not multiples:
-            # Grab first item
-            try:
-                cur = cur[0]
-            # If no items were returned
-            except IndexError:
-                logger.debug("No items found when searching for multiples")
-        return cur
+        yield from self._collection.find(device_info)
 
     def save(self, _id, post, insert=True):
         """

--- a/happi/backends/mongo_db.py
+++ b/happi/backends/mongo_db.py
@@ -165,4 +165,4 @@ class MongoBackend(_Backend):
         """
         res = self._collection.delete_one({'_id': _id})
         if res.deleted_count < 1:
-            raise ValueError(f'ID not found in database: {_id!r}')
+            raise SearchError(f'ID not found in database: {_id!r}')

--- a/happi/backends/mongo_db.py
+++ b/happi/backends/mongo_db.py
@@ -163,4 +163,6 @@ class MongoBackend(_Backend):
         _id : str
             ID of device
         """
-        self._collection.delete_one({'_id': _id})
+        res = self._collection.delete_one({'_id': _id})
+        if res.deleted_count < 1:
+            raise ValueError(f'ID not found in database: {_id!r}')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -95,11 +95,11 @@ def happi_cli(args):
                 value = float(value)
             client_args[criteria] = value
 
-        devices = client.search(**client_args)
-        if devices:
-            for dev in devices:
-                dev.show_info()
-            return devices
+        results = client.search(**client_args)
+        if results:
+            for res in results:
+                res.device.show_info()
+            return results
         else:
             logger.error('No devices found')
     elif args.cmd == 'add':

--- a/happi/client.py
+++ b/happi/client.py
@@ -328,7 +328,8 @@ class Client:
             hxr_valves  = client.search_key('z', 0, 100, type='Valve',
                                             beamline='HXR')
         """
-        items = self.backend.find_range(key, start, end, kwargs)
+        items = self.backend.find_range(key, start=start, stop=end,
+                                        to_match=kwargs)
         if as_dict:
             return list(items)
 

--- a/happi/client.py
+++ b/happi/client.py
@@ -324,9 +324,9 @@ class Client:
         Example
         .. code::
 
-            gate_valves = client.search_key('z', 0, 100, type='Valve')
-            hxr_valves  = client.search_key('z', 0, 100, type='Valve',
-                                            beamline='HXR')
+            gate_valves = client.search_range('z', 0, 100, type='Valve')
+            hxr_valves  = client.search_range('z', 0, 100, type='Valve',
+                                              beamline='HXR')
         """
         items = self.backend.find_range(key, start=start, stop=end,
                                         to_match=kwargs)

--- a/happi/client.py
+++ b/happi/client.py
@@ -74,7 +74,7 @@ class SearchResult(collections.abc.Mapping):
         )
 
 
-class Client:
+class Client(collections.abc.Mapping):
     """
     The client to control the contents of the Happi Database
 
@@ -340,6 +340,13 @@ class Client:
     def __getitem__(self, key):
         'Get a device ID'
         return SearchResult(client=self, metadata=self.backend.get_by_id(key))
+
+    def __iter__(self):
+        for info in self.backend.find({}):
+            yield info['_id']
+
+    def __len__(self):
+        return len(self.all_devices)
 
     def _get_search_results(self, items, *, wrap_cls=None):
         '''

--- a/happi/client.py
+++ b/happi/client.py
@@ -384,12 +384,8 @@ class Client:
         logger.info("Attempting to remove %r from the "
                     "collection ...", device)
         # Check that device is in the database
-        try:
-            _id = getattr(device, self._id)
-            self.backend.delete(_id)
-        except SearchError:
-            logger.exception('Target device was not found in the database')
-            raise
+        _id = getattr(device, self._id)
+        self.backend.delete(_id)
 
     def _validate_device(self, device):
         """

--- a/happi/client.py
+++ b/happi/client.py
@@ -292,6 +292,9 @@ class Client:
         """
         return self.search()
 
+    def __getitem__(self, key):
+        return self.backend.get_by_id(key)
+
     def search(self, start=0., end=None, as_dict=False, **kwargs):
         """
         Search the database for a device or devices

--- a/happi/client.py
+++ b/happi/client.py
@@ -386,13 +386,10 @@ class Client:
         # Check that device is in the database
         try:
             _id = getattr(device, self._id)
-            self.find_document(_id=_id)
-        # Log and re-raise
+            self.backend.delete(_id)
         except SearchError:
             logger.exception('Target device was not found in the database')
             raise
-        else:
-            self.backend.delete(_id)
 
     def _validate_device(self, device):
         """

--- a/happi/client.py
+++ b/happi/client.py
@@ -3,6 +3,7 @@ import inspect
 import itertools
 import logging
 import os
+import re
 import sys
 import time as ttime
 
@@ -360,6 +361,41 @@ class Client:
             hxr_valves  = client.search(type='Valve', beamline='HXR')
         """
         items = self.backend.find(kwargs)
+        if as_dict:
+            return list(items)
+
+        return [self.find_device(**info) for info in items]
+
+    def search_regex(self, flags=re.IGNORECASE, as_dict=False, **kwargs):
+        """
+        Search the database for a device or devices
+
+        Parameters
+        -----------
+        as_dict : bool, optional
+            Return the information as a list of dictionaries or a list of
+            :class:`.HappiItem`
+
+        flags : int, optional
+            Defaulting to ``re.IGNORECASE``, these flags are used for the
+            regular expressions passed in.
+
+        **kwargs
+            Information to filter through the database structured as key, value
+            pairs for the desired pieces of EntryInfo.  Every value is allowed
+            to contain a Python regular expression.
+
+        Returns
+        -------
+        Either a list of devices or dictionaries
+
+        Example
+        .. code::
+
+            gate_valves = client.search_regex(beamline='Valve.*')
+            three_valves = client.search_regex(_id='VALVE[123]')
+        """
+        items = self.backend.find_regex(kwargs, flags=flags)
         if as_dict:
             return list(items)
 

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -215,3 +215,61 @@ def mockqsbackend():
         # Instantiate a fake device
         backend = QSBackend('tstlr3216')
         return backend
+
+
+@pytest.fixture(scope='function')
+def three_valves(happi_client):
+    valve1 = {'name': 'valve1',
+              'z': 300,
+              'prefix': 'BASE:VGC1:PV',
+              '_id': 'VALVE1',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'type': 'Device',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              'device_class': 'types.SimpleNamespace',
+              'args': list(),
+              'kwargs': {'hi': 'oh hello'},
+              }
+
+    valve2 = {'name': 'valve2',
+              'z': 301,
+              'prefix': 'BASE:VGC2:PV',
+              '_id': 'VALVE2',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'type': 'Device',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              'device_class': 'types.SimpleNamespace',
+              'args': list(),
+              'kwargs': {'hi': 'oh hello'},
+              }
+
+    valve3 = {'name': 'valve3',
+              'z': 301,
+              'prefix': 'BASE:VGC3:PV',
+              '_id': 'VALVE3',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              'type': 'Device',
+              'device_class': 'types.SimpleNamespace',
+              'args': list(),
+              'kwargs': {'hi': 'oh hello'},
+              }
+
+    for dev in happi_client.all_devices:
+        happi_client.backend.delete(dev['_id'])
+
+    valves = dict(
+        VALVE1=valve1,
+        VALVE2=valve2,
+        VALVE3=valve3,
+    )
+
+    for name, valve in valves.items():
+        happi_client.backend.save(name, valve, insert=True)
+    return valves

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -104,6 +104,62 @@ def test_json_find(valve_info, device_info, mockjson):
     assert all([info in result for info in (device_info, valve_info)])
 
 
+def test_json_find_regex(valve_info, device_info, mockjson):
+    mm = mockjson
+    # Write underlying database
+    valve1 = {'name': 'VALVE1',
+              'z': 300,
+              'prefix': 'BASE:VGC1:PV',
+              '_id': 'VALVE1',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              }
+
+    valve2 = {'name': 'VALVE2',
+              'z': 301,
+              'prefix': 'BASE:VGC2:PV',
+              '_id': 'VALVE2',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              }
+
+    valve3 = {'name': 'VALVE3',
+              'z': 301,
+              'prefix': 'BASE:VGC3:PV',
+              '_id': 'VALVE3',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              }
+
+    with open(mm.path, 'w+') as handle:
+        simplejson.dump(
+            {'VALVE1': valve1,
+             'VALVE2': valve2,
+             'VALVE3': valve3,
+             },
+            handle
+        )
+
+    assert mm.find_regex(beamline='LCLS', multiples=False) == valve1
+    assert mm.find_regex(beamline='LCLS', multiples=True) == [
+        valve1, valve2, valve3]
+    assert mm.find_regex(beamline='lcls', multiples=True) == [
+        valve1, valve2, valve3]
+    assert mm.find_regex(beamline='nomatch', multiples=True) == []
+    assert mm.find_regex(_id=r'VALVE\d', multiples=True) == [
+        valve1, valve2, valve3]
+    assert mm.find_regex(_id='VALVE[13]', multiples=True) == [
+        valve1, valve3]
+    assert mm.find_regex(prefix='BASE:VGC[23]:PV', multiples=True) == [
+        valve2, valve3]
+
+
 def test_json_delete(mockjson, device_info):
     mockjson.delete(device_info[Client._id])
     assert device_info not in mockjson.all_devices

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -34,25 +34,24 @@ def mockjson(device_info, valve_info):
 def test_mongo_find(valve_info, device_info, mockmongo):
     mm = mockmongo
     mm._collection.insert_one(valve_info)
-    # No single device expected
-    assert mm.find(beamline='BLERG', multiples=False) == []
+
+    def find(**kwargs):
+        return list(mm.find(kwargs))
+
+    assert find(beamline='BLERG') == []
     # Single device by id
-    assert device_info == mm.find(_id=device_info['_id'],
-                                  multiples=False)
+    assert [device_info] == find(_id=device_info['_id'])
     # Single device by kwarg
-    assert valve_info == mm.find(prefix=valve_info['prefix'],
-                                 multiples=False)
+    assert [valve_info] == find(prefix=valve_info['prefix'])
     # No multiple devices expected
-    assert mm.find(beamline='BLERG', multiples=False) == []
+    assert find(beamline='BLERG') == []
     # Multiple devices by id
-    assert [device_info] == mm.find(_id=device_info['_id'],
-                                    multiples=True)
+    assert [device_info] == find(_id=device_info['_id'])
     # Multiple devices by kwarg
-    assert [device_info] == mm.find(prefix=device_info['prefix'],
-                                    multiples=True)
+    assert [device_info] == find(prefix=device_info['prefix'])
     # Multiple devices expected
-    result = mm.find(beamline='LCLS', multiples=True)
-    assert all([info in result for info in (device_info, valve_info)])
+    assert all(info in find(beamline='LCLS')
+               for info in (device_info, valve_info))
 
 
 @requires_mongo

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -103,53 +103,7 @@ def test_json_find(valve_info, device_info, mockjson):
                for info in (device_info, valve_info))
 
 
-@pytest.fixture(scope='function')
-def three_valves(happi_client):
-    valve1 = {'name': 'VALVE1',
-              'z': 300,
-              'prefix': 'BASE:VGC1:PV',
-              '_id': 'VALVE1',
-              'beamline': 'LCLS',
-              'mps': 'MPS:VGC:PV',
-              'location_group': 'LOC',
-              'functional_group': 'FUNC',
-              }
-
-    valve2 = {'name': 'VALVE2',
-              'z': 301,
-              'prefix': 'BASE:VGC2:PV',
-              '_id': 'VALVE2',
-              'beamline': 'LCLS',
-              'mps': 'MPS:VGC:PV',
-              'location_group': 'LOC',
-              'functional_group': 'FUNC',
-              }
-
-    valve3 = {'name': 'VALVE3',
-              'z': 301,
-              'prefix': 'BASE:VGC3:PV',
-              '_id': 'VALVE3',
-              'beamline': 'LCLS',
-              'mps': 'MPS:VGC:PV',
-              'location_group': 'LOC',
-              'functional_group': 'FUNC',
-              }
-
-    for dev in happi_client.all_devices:
-        happi_client.backend.delete(dev['_id'])
-
-    valves = dict(
-        VALVE1=valve1,
-        VALVE2=valve2,
-        VALVE3=valve3,
-    )
-
-    for name, valve in valves.items():
-        happi_client.backend.save(name, valve, insert=True)
-    return valves
-
-
-def test_mongo_find_regex(happi_client, three_valves):
+def test_find_regex(happi_client, three_valves):
     def find(**kwargs):
         return list(happi_client.backend.find_regex(kwargs))
 

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -103,6 +103,60 @@ def test_json_find(valve_info, device_info, mockjson):
                for info in (device_info, valve_info))
 
 
+def test_mongo_find_regex(valve_info, device_info, mockmongo):
+    mm = mockmongo
+    # Write underlying database
+    valve1 = {'name': 'VALVE1',
+              'z': 300,
+              'prefix': 'BASE:VGC1:PV',
+              '_id': 'VALVE1',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              }
+
+    valve2 = {'name': 'VALVE2',
+              'z': 301,
+              'prefix': 'BASE:VGC2:PV',
+              '_id': 'VALVE2',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              }
+
+    valve3 = {'name': 'VALVE3',
+              'z': 301,
+              'prefix': 'BASE:VGC3:PV',
+              '_id': 'VALVE3',
+              'beamline': 'LCLS',
+              'mps': 'MPS:VGC:PV',
+              'location_group': 'LOC',
+              'functional_group': 'FUNC',
+              }
+
+    for dev in mm.all_devices:
+        mm.delete(dev['_id'])
+
+    for dev in mm.all_devices:
+        print('found', dev)
+
+    mm.save('VALVE1', valve1, insert=True)
+    mm.save('VALVE2', valve2, insert=True)
+    mm.save('VALVE3', valve3, insert=True)
+
+    def find(**kwargs):
+        return list(mm.find_regex(kwargs))
+
+    assert find(beamline='LCLS') == [valve1, valve2, valve3]
+    assert find(beamline='lcls') == [valve1, valve2, valve3]
+    assert find(beamline='nomatch') == []
+    assert find(_id=r'VALVE\d') == [valve1, valve2, valve3]
+    assert find(_id='VALVE[13]') == [valve1, valve3]
+    assert find(prefix='BASE:VGC[23]:PV') == [valve2, valve3]
+
+
 def test_json_find_regex(valve_info, device_info, mockjson):
     mm = mockjson
     # Write underlying database

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -83,25 +83,25 @@ def test_json_find(valve_info, device_info, mockjson):
         simplejson.dump({valve_info['_id']: valve_info,
                          device_info['_id']: device_info},
                         handle)
+
+    def find(**kwargs):
+        return list(mm.find(kwargs))
+
     # No single device expected
-    assert mm.find(beamline='BLERG', multiples=False) == []
+    assert find(beamline='BLERG') == []
     # Single device by id
-    assert device_info == mm.find(_id=device_info['_id'],
-                                  multiples=False)
+    assert [device_info] == find(_id=device_info['_id'])
     # Single device by kwarg
-    assert valve_info == mm.find(prefix=valve_info['prefix'],
-                                 multiples=False)
+    assert [valve_info] == find(prefix=valve_info['prefix'])
     # No multiple devices expected
-    assert mm.find(beamline='BLERG', multiples=False) == []
+    assert find(beamline='BLERG') == []
     # Multiple devices by id
-    assert [device_info] == mm.find(_id=device_info['_id'],
-                                    multiples=True)
+    assert [device_info] == find(_id=device_info['_id'])
     # Multiple devices by kwarg
-    assert [device_info] == mm.find(prefix=device_info['prefix'],
-                                    multiples=True)
+    assert [device_info] == find(prefix=device_info['prefix'])
     # Multiple devices expected
-    result = mm.find(beamline='LCLS', multiples=True)
-    assert all([info in result for info in (device_info, valve_info)])
+    assert all(info in find(beamline='LCLS')
+               for info in (device_info, valve_info))
 
 
 def test_json_find_regex(valve_info, device_info, mockjson):
@@ -146,18 +146,15 @@ def test_json_find_regex(valve_info, device_info, mockjson):
             handle
         )
 
-    assert mm.find_regex(beamline='LCLS', multiples=False) == valve1
-    assert mm.find_regex(beamline='LCLS', multiples=True) == [
-        valve1, valve2, valve3]
-    assert mm.find_regex(beamline='lcls', multiples=True) == [
-        valve1, valve2, valve3]
-    assert mm.find_regex(beamline='nomatch', multiples=True) == []
-    assert mm.find_regex(_id=r'VALVE\d', multiples=True) == [
-        valve1, valve2, valve3]
-    assert mm.find_regex(_id='VALVE[13]', multiples=True) == [
-        valve1, valve3]
-    assert mm.find_regex(prefix='BASE:VGC[23]:PV', multiples=True) == [
-        valve2, valve3]
+    def find(**kwargs):
+        return list(mm.find_regex(kwargs))
+
+    assert find(beamline='LCLS') == [valve1, valve2, valve3]
+    assert find(beamline='lcls') == [valve1, valve2, valve3]
+    assert find(beamline='nomatch') == []
+    assert find(_id=r'VALVE\d') == [valve1, valve2, valve3]
+    assert find(_id='VALVE[13]') == [valve1, valve3]
+    assert find(prefix='BASE:VGC[23]:PV') == [valve2, valve3]
 
 
 def test_json_delete(mockjson, device_info):
@@ -204,8 +201,8 @@ def test_json_initialize():
 @pytest.mark.xfail
 @requires_questionnaire
 def test_qs_find(mockqsbackend):
-    assert len(mockqsbackend.find(beamline='TST', multiples=True)) == 14
-    assert len(mockqsbackend.find(name='sam_r', multiples=True)) == 1
+    assert len(mockqsbackend.find(dict(beamline='TST', multiples=True))) == 14
+    assert len(mockqsbackend.find(dict(name='sam_r', multiples=True))) == 1
 
 
 @pytest.mark.xfail

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -81,15 +81,15 @@ def test_cli_version(capsys):
 
 def test_search(happi_cfg):
     client = happi.client.Client.from_config(cfg=happi_cfg)
-    devices = client.search(beamline="TST")
-    devices_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg,
-                                       'search', 'beamline=TST'])
-    assert devices == devices_cli
+    res = client.search(beamline="TST")
+    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
+                                   'beamline=TST'])
+    assert [r.device for r in res] == [r.device for r in res_cli]
 
 
 def test_search_z(happi_cfg):
     client = happi.client.Client.from_config(cfg=happi_cfg)
-    devices = client.search(z=6.0)
-    devices_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg,
-                                       'search', 'z=6.0'])
-    assert devices == devices_cli
+    res = client.search(z=6.0)
+    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
+                                   'z=6.0'])
+    assert [r.device for r in res] == [r.device for r in res_cli]

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -189,6 +189,13 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     assert len(res) == 2
 
 
+def test_get_by_id(happi_client, device, valve, device_info, valve_info):
+    happi_client.add_device(valve)
+    name = valve_info['name']
+    for k, v in valve_info.items():
+        assert happi_client[name][k] == valve_info[k]
+
+
 def test_remove_device(happi_client, device, valve, device_info):
     happi_client.remove_device(device)
     assert list(happi_client.backend.find(device_info)) == []

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -199,9 +199,9 @@ def test_search_regex(happi_client, three_valves):
             happi_client.search_regex(**kwargs, flags=re.IGNORECASE)
         ]
 
-    valve1 = happi_client.find_device(**happi_client['VALVE1']).post()
-    valve2 = happi_client.find_device(**happi_client['VALVE2']).post()
-    valve3 = happi_client.find_device(**happi_client['VALVE3']).post()
+    valve1 = happi_client['VALVE1'].post()
+    valve2 = happi_client['VALVE2'].post()
+    valve3 = happi_client['VALVE3'].post()
 
     assert find(beamline='LCLS') == [valve1, valve2, valve3]
     assert find(beamline='lcls') == [valve1, valve2, valve3]
@@ -273,3 +273,17 @@ def test_choices_for_field(happi_client):
     assert prefix_choices == {'BASE:PV'}
     with pytest.raises(SearchError):
         happi_client.choices_for_field('not_a_field')
+
+
+def test_metadata_proxy(happi_client, three_valves):
+    valve1 = happi_client['VALVE1']
+    print(repr(valve1))
+    print(dict(valve1))
+    base_keys = list(valve1.metadata)
+
+    def only_basic_keys(md):
+        return {k: v for k, v in md.items() if k in base_keys}
+
+    assert valve1.metadata == only_basic_keys(valve1.device.post())
+    assert valve1.metadata == only_basic_keys(valve1.post())
+    assert isinstance(valve1.get(), types.SimpleNamespace)

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -170,23 +170,26 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     assert loaded_device['name'] == device_info['name']
     assert loaded_device['z'] == device_info['z']
     assert loaded_device['beamline'] == device_info['beamline']
+    # Search off keyword
+    res = happi_client.search(beamline='LCLS')
+    assert len(res) == 2
+
+
+def test_search_range(happi_client, device, valve, device_info, valve_info):
+    happi_client.add_device(valve)
     # Search between two points
     res = happi_client.search_range('z', start=0, end=500)
     assert len(res) == 2
-    loaded_device = res[0]
+
     # Search between two points, nothing found
     res = happi_client.search_range('z', start=10000, end=500000)
     assert not res
     # Search without an endpoint
     res = happi_client.search_range('z', start=0)
     assert len(res) == 2
-    loaded_device = res[1]
     # Search invalid range
     with pytest.raises(ValueError):
         happi_client.search_range('z', start=1000, end=5)
-    # Search off keyword
-    res = happi_client.search(beamline='LCLS')
-    assert len(res) == 2
 
 
 def test_get_by_id(happi_client, device, valve, device_info, valve_info):

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -195,13 +195,13 @@ def test_search_range(happi_client, device, valve, device_info, valve_info):
 def test_search_regex(happi_client, three_valves):
     def find(**kwargs):
         return [
-            item.post() for item in
+            dict(item) for item in
             happi_client.search_regex(**kwargs, flags=re.IGNORECASE)
         ]
 
-    valve1 = happi_client['VALVE1'].post()
-    valve2 = happi_client['VALVE2'].post()
-    valve3 = happi_client['VALVE3'].post()
+    valve1 = dict(happi_client['VALVE1'])
+    valve2 = dict(happi_client['VALVE2'])
+    valve3 = dict(happi_client['VALVE3'])
 
     assert find(beamline='LCLS') == [valve1, valve2, valve3]
     assert find(beamline='lcls') == [valve1, valve2, valve3]
@@ -279,13 +279,7 @@ def test_searchresults(happi_client, three_valves):
     valve1 = happi_client['VALVE1']
     print(repr(valve1))
     print(dict(valve1))
-    base_keys = list(valve1.metadata)
-
-    def only_basic_keys(md):
-        return {k: v for k, v in md.items() if k in base_keys}
-
-    assert valve1.metadata == only_basic_keys(valve1.device.post())
-    assert valve1.metadata == only_basic_keys(valve1.post())
+    assert valve1.metadata == valve1
     assert isinstance(valve1.get(), types.SimpleNamespace)
 
 

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -171,19 +171,19 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     assert loaded_device['z'] == device_info['z']
     assert loaded_device['beamline'] == device_info['beamline']
     # Search between two points
-    res = happi_client.search(start=0, end=500)
+    res = happi_client.search_range('z', start=0, end=500)
     assert len(res) == 2
     loaded_device = res[0]
     # Search between two points, nothing found
-    res = happi_client.search(start=10000, end=500000)
+    res = happi_client.search_range('z', start=10000, end=500000)
     assert not res
     # Search without an endpoint
-    res = happi_client.search(start=0)
+    res = happi_client.search_range('z', start=0)
     assert len(res) == 2
     loaded_device = res[1]
     # Search invalid range
     with pytest.raises(ValueError):
-        happi_client.search(start=1000, end=5)
+        happi_client.search_range('z', start=1000, end=5)
     # Search off keyword
     res = happi_client.search(beamline='LCLS')
     assert len(res) == 2

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -157,7 +157,7 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     res = happi_client.search(name=device_info['name'])
     # Single search return
     assert len(res) == 1
-    loaded_device = res[0]
+    loaded_device = res[0].device
     assert loaded_device.prefix == device_info['prefix']
     assert loaded_device.name == device_info['name']
     assert loaded_device.z == device_info['z']
@@ -165,8 +165,8 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     # No results
     assert not happi_client.search(name='not')
     # Returned as dict
-    res = happi_client.search(as_dict=True, **device_info)
-    loaded_device = res[0]
+    res = happi_client.search(**device_info)
+    loaded_device = res[0].device
     assert loaded_device['prefix'] == device_info['prefix']
     assert loaded_device['name'] == device_info['name']
     assert loaded_device['z'] == device_info['z']

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -162,7 +162,7 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     assert loaded_device.z == device_info['z']
     assert loaded_device.beamline == device_info['beamline']
     # No results
-    assert happi_client.search(name='not') is None
+    assert not happi_client.search(name='not')
     # Returned as dict
     res = happi_client.search(as_dict=True, **device_info)
     loaded_device = res[0]
@@ -176,7 +176,7 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     loaded_device = res[0]
     # Search between two points, nothing found
     res = happi_client.search(start=10000, end=500000)
-    assert res is None
+    assert not res
     # Search without an endpoint
     res = happi_client.search(start=0)
     assert len(res) == 2
@@ -191,7 +191,7 @@ def test_search(happi_client, device, valve, device_info, valve_info):
 
 def test_remove_device(happi_client, device, valve, device_info):
     happi_client.remove_device(device)
-    assert happi_client.backend.find(**device_info) == []
+    assert list(happi_client.backend.find(device_info)) == []
     # Invalid Device
     with pytest.raises(ValueError):
         happi_client.remove_device(5)

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -275,7 +275,7 @@ def test_choices_for_field(happi_client):
         happi_client.choices_for_field('not_a_field')
 
 
-def test_metadata_proxy(happi_client, three_valves):
+def test_searchresults(happi_client, three_valves):
     valve1 = happi_client['VALVE1']
     print(repr(valve1))
     print(dict(valve1))
@@ -287,3 +287,10 @@ def test_metadata_proxy(happi_client, three_valves):
     assert valve1.metadata == only_basic_keys(valve1.device.post())
     assert valve1.metadata == only_basic_keys(valve1.post())
     assert isinstance(valve1.get(), types.SimpleNamespace)
+
+
+def test_client_mapping(happi_client, three_valves):
+    assert len(happi_client) == 3
+    assert list(dict(happi_client)) == ['VALVE1', 'VALVE2', 'VALVE3']
+    for name in happi_client:
+        assert happi_client[name]['name']


### PR DESCRIPTION
## Description
Working on getting full-match find alternatives such as:
* Find by regex
* Fuzzy find

## Motivation and Context
Closes #4 
Hopes to address #98 eventually

## Where Has This Been Documented?
Docstrings, not docs yet

## API change
I expect that different backends could support different search methods, requiring only `find` to be fully supported. 

I'm definitely open to suggestions as to how this should look.