### PR TITLE
FIX: Device add and save

### DIFF
--- a/happi/client.py
+++ b/happi/client.py
@@ -114,7 +114,7 @@ class Client(collections.abc.Mapping):
     """
     # HappiItem information
     _client_attrs = ['_id', 'type', 'creation', 'last_edit']
-    _id = 'name'
+    _id_key = 'name'
     _results_wrap_class = SearchResult
     # Store device types seen by client
     device_types = {'Device': Device,
@@ -329,7 +329,7 @@ class Client(collections.abc.Mapping):
             # Try and load device based on database info
             try:
                 # HappiItem identification
-                _id = post[self._id]
+                _id = post[self._id_key]
                 logger.debug('Attempting to initialize %s...', _id)
                 # Load HappiItem
                 device = self.find_device(**post)
@@ -507,7 +507,7 @@ class Client(collections.abc.Mapping):
         logger.info("Attempting to remove %r from the "
                     "collection ...", device)
         # Check that device is in the database
-        _id = getattr(device, self._id)
+        _id = getattr(device, self._id_key)
         self.backend.delete(_id)
 
     def _validate_device(self, device):
@@ -578,14 +578,15 @@ class Client(collections.abc.Mapping):
                      'last_edit': ttime.ctime()})
         # Find id
         try:
-            _id = post[self._id]
+            _id = post[self._id_key]
         except KeyError:
             raise EntryError('HappiItem did not supply the proper information '
                              'to interface with the database, missing {}'
-                             ''.format(self._id))
+                             ''.format(self._id_key))
         # Store information
         logger.info('Adding / Modifying information for %s ...', _id)
         self.backend.save(_id, post, insert=insert)
+        return _id
 
     @classmethod
     def from_config(cls, cfg=None):

--- a/happi/client.py
+++ b/happi/client.py
@@ -221,7 +221,11 @@ class Client(collections.abc.Mapping):
                             'HappiItem'.format(device_cls))
         device = device_cls(**kwargs)
         # Add the method to the device
-        device.save = lambda: self.add_device(device)
+
+        def save_device():
+            self.add_device(device)
+
+        device.save = save_device
         return device
 
     def add_device(self, device):
@@ -241,11 +245,15 @@ class Client(collections.abc.Mapping):
             database
         """
         logger.info("Storing device %r ...", device)
-        # Store post
-        self._store(device, insert=True)
-        # Log success
+        _id = self._store(device, insert=True)
         logger.info('HappiItem %r has been succesfully added to the '
                     'database', device)
+
+        def save_device():
+            self._store(device, insert=False)
+
+        device.save = save_device
+        return _id
 
     def find_device(self, **post):
         """

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -58,20 +58,20 @@ def test_mongo_find(valve_info, device_info, mockmongo):
 def test_mongo_save(mockmongo, device_info, valve_info):
     # Duplicate device
     with pytest.raises(DuplicateError):
-        mockmongo.save(device_info[Client._id], device_info, insert=True)
+        mockmongo.save(device_info[Client._id_key], device_info, insert=True)
 
     # Device not found
     with pytest.raises(SearchError):
-        mockmongo.save(valve_info[Client._id], valve_info, insert=False)
+        mockmongo.save(valve_info[Client._id_key], valve_info, insert=False)
 
     # Add to database
-    mockmongo.save(valve_info[Client._id], valve_info, insert=True)
+    mockmongo.save(valve_info[Client._id_key], valve_info, insert=True)
     assert mockmongo._collection.find_one(valve_info) == valve_info
 
 
 @requires_mongo
 def test_mongo_delete(mockmongo, device_info):
-    mockmongo.delete(device_info[Client._id])
+    mockmongo.delete(device_info[Client._id_key])
     assert mockmongo._collection.find_one(device_info) is None
 
 
@@ -119,21 +119,21 @@ def test_find_regex(happi_client, three_valves):
 
 
 def test_json_delete(mockjson, device_info):
-    mockjson.delete(device_info[Client._id])
+    mockjson.delete(device_info[Client._id_key])
     assert device_info not in mockjson.all_devices
 
 
 def test_json_save(mockjson, device_info, valve_info):
     # Duplicate device
     with pytest.raises(DuplicateError):
-        mockjson.save(device_info[Client._id], device_info, insert=True)
+        mockjson.save(device_info[Client._id_key], device_info, insert=True)
 
     # Device not found
     with pytest.raises(SearchError):
-        mockjson.save(valve_info[Client._id], valve_info, insert=False)
+        mockjson.save(valve_info[Client._id_key], valve_info, insert=False)
 
     # Add to database
-    mockjson.save(valve_info[Client._id], valve_info, insert=True)
+    mockjson.save(valve_info[Client._id_key], valve_info, insert=True)
     assert valve_info in mockjson.all_devices
 
 

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -148,7 +148,8 @@ def test_validate(happi_client):
     # No bad devices
     assert happi_client.validate() == list()
     # A single bad device
-    happi_client.backend.save('_id', {happi_client._id: 'bad'}, insert=True)
+    happi_client.backend.save('_id', {happi_client._id_key: 'bad'},
+                              insert=True)
     assert happi_client.validate() == ['bad']
 
 

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -121,3 +121,12 @@ def test_device_deepcopy():
     c = copy.deepcopy(a)
     assert a.kwargs == c.kwargs
     assert id(a.kwargs) != id(c.kwargs)
+
+
+def test_add_and_save(three_valves, device, happi_client):
+    device.active = True
+    happi_client.add_device(device)
+    device.active = False
+    device.save()
+
+    assert not happi_client[device.name].device.active


### PR DESCRIPTION
Closes #55 

Separately, renames `Client._id` -> `Client._id_key` as the lack of description made it confusing.