### PR TITLE
DOC: Release Notes & other fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,8 +47,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.autosummary',
               'IPython.sphinxext.ipython_directive',
-              'IPython.sphinxext.ipython_console_highlighting',
-              'sphinx.ext.autosectionlabel'
+              'IPython.sphinxext.ipython_console_highlighting'
               ]
 
 # In case we don't have the backend libraries installed

--- a/docs/source/containers.rst
+++ b/docs/source/containers.rst
@@ -1,43 +1,30 @@
 .. _device_label:
 
-Device Containers
-=================
-Device
-------
-A generic device container is available for use that holds a few basic traits
-pertinent to all LCLS devices. Largely this is available to provide a common
+Containers
+==========
+
+A generic container is available for use that holds a few basic traits
+pertinent to Ophyd devices. Largely this is available to provide a common
 base that more specific devices will inherit from.
 
-.. autoclass:: happi.Device
-   :members:
+.. autoclass:: happi.OphydItem
+    :members:
 
 These inherit from the most generic information that can be included:
 
 .. autoclass:: happi.HappiItem
-   :members:
+    :members:
 
-Containers
-----------
-Each of the containers below share the attributes and entries of the generic
-Device container. This section documents the entries when they either do not
-exist in the generic device or require further clarification on a case-by-case
-basis.
+Extending Containers
+--------------------
 
-.. autosummary::
-   :toctree: generated
+Happi allow users to extend the containers list via Python
+`entry points <https://packaging.python.org/specifications/entry-points/>`_
+specified by the **happi.containers** keyword. An example entry points can be
+found `here <https://github.com/pcdshub/pcdsdevices/blob/master/setup.py>`_.
 
-   happi.containers.GateValve
-   happi.containers.Slits
-   happi.containers.PIM
-   happi.containers.PIM
-   happi.containers.IPM
-   happi.containers.Attenuator
-   happi.containers.Stopper
-   happi.containers.OffsetMirror
-   happi.containers.PulsePicker
-   happi.containers.LODCM
-   happi.containers.MovableStand
-   happi.containers.Motor
+`HappiRegistry` takes care of loading the entry points and making them
+available throughout the library.
 
 Loading Containers
 ------------------

--- a/docs/source/conventions.rst
+++ b/docs/source/conventions.rst
@@ -21,7 +21,7 @@ prefix
 ++++++
 This should be the prefix for all of the PVs contained within the device. It does
 not matter if this is an invalid record by itself. Each Device Container will
-have it's own convention for base PV. See :ref:`Containers`.
+have it's own convention for base PV. See :ref:`device_label`.
 
 
 beamline

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,51 +1,303 @@
-#############
-Release Notes
-#############
+=================
+ Release History
+=================
+
+
+v1.6.0 (2020-04-30)
+===================
+
+-  LCLS-specific containers are moved out of happi, and into
+   `pcdsdevices <https://github.com/pcdshub/pcdsdevices/tree/master/pcdsdevices/happi>`__
+-  ``OphydItem`` is now the preferred “basic” ``ophyd.Device``
+   container, with the intention of fully deprecating ``Device`` to
+   avoid naming confusion
+-  Minor internal fixes
+
+
+v1.5.0 (2020-04-06)
+===================
+
+-  Refactor search methods, supporting mongo and JSON backends
+
+   -  ``search`` - search by key/value pairs as kwargs
+   -  ``search_range`` - search for a range of values in a specific key
+   -  ``search_regex`` - search for key/value pairs as kwargs, with
+      values being regular expressions
+   -  Adds ``SearchResult`` container, allowing for access of metadata
+      or device instantiation
+
+-  ``Client['item']`` supported
+-  ``happi.Device`` is now marked as deprecated
+
+   -  Migrate to ``happi.OphydItem``
+
+-  Documentation building fixed and made more accurate
+-  Internal refactoring
+
+   -  Reduce usage of metaclasses
+   -  pymongo/mongomock are truly optional test dependencies now
+   -  Added pre-commit configuration for developer quality-of-life
+   -  ``HappiItem``\ s are now ``copy.copy()``-able
+   -  Backends supply generators and not lists
+
+-  Fixed many oustanding issues with the JSON backend
+
+
+v1.4.0 (2020-03-13)
+===================
+
+Enhancements
+------------
+
+-  Add an add command for cli, e.g. happi add to start an interactive
+   device adder
+-  Add an edit command for cli, e.g. happi edit im3l0 location=750
+   prefix=IM3L0:PPM
+-  Change search command syntax to be simpler (more like edit)
+-  Add a load command for cli, e.g. happi load im3l0 im1l1 -> IPython
+   session plus other changes made in dev to “get it working”
+-  Add two new Happi-aware Qt widgets: HappiDeviceListView &
+   HappiDeviceTreeView
+
+Bug Fixes
+---------
+
+-  Initialize database if it does not yet exists
+-  Fix broken tests
+
+
+v1.3.0 (2019-12-10)
+===================
+
+Enhancements
+------------
+
+-  Command line script allow users to search and add devices
+   `#84 <https://github.com/pcdshub/happi/issues/84>`__
+-  Base ``Container`` object now available with minimum amount of
+   ``EntryInfo`` `#92 <https://github.com/pcdshub/happi/issues/92>`__
+-  Allow Happi to load more devices from LCLS questionnaire
+   `#94 <https://github.com/pcdshub/happi/issues/94>`__
+-  New function ``list_choices`` added to ``happi.Client`` to allow user
+   to know what beamlines, prefixes, names, etc. will return results.
+-  Threaded ``load_devices`` with option to specify a callback when
+   devices are ready
+   `#67 <https://github.com/pcdshub/happi/issues/67>`__
+
+
+v1.2.1 (2019-03-07)
+===================
+
+Bug Fixes
+---------
+
+-  The test suite now passes without the ``mongomock`` backend
+   (`#89 <https://github.com/pcdshub/happi/issues/89>`__)
+-  Ensure our file handles are properly closed in the JSON backend by
+   using context managers
+   (`#87 <https://github.com/pcdshub/happi/issues/87>`__)
+
+
+v1.2.0 (2018-12-19)
+===================
+
+Enhancements
+------------
+
+-  ``Client`` now has a method ``load_device`` for searching the
+   database for a ``Container`` and then loading the corresponding
+   object based on ``device_class``, ``args`` and ``kwargs``. This is a
+   shortcut to combine two previously existing features
+   ``Client.find_device`` and ``happi.loader.from_container``
+
+-  ``Client.from_config`` will create a ``Client`` object from a
+   provided configuration file. You can either pass this file in
+   explicitly, specify it via the the environment variable
+   ``$HAPPI_CFG``, or it will be searched for in ``~config`` or wherever
+   you specify your \`$XDG_CONFIG_HOME environment variable
+
+-  Additional keywords were added to the base ``Device`` container;
+   ``lightpath``, ``documentation`` and ``embedded_screen``,
+   ``detailed_screen`` and ``engineering_screen``
+
+-  There is now a base container for a ``Motor`` object.
+
+Deprecations
+------------
+
+-  ``screen`` is longer a supported key. This was too generic and the
+   three keys detailed above allow the user more specificity.
+
+Fixes
+-----
+
+-  The ``JSONBackend`` no longer relies on ``fcntl`` a Linux only module
+   of the Python standard library.
+
 
 v1.1.2 (2018-08-30)
 ===================
 
-**Maintenance**
+Maintenance
+-----------
 
-- In :meth:`.from_container`, the provided container is compared against
-  the cached version of the device to find discrepancies. This means that
-  modified container objects will always load a new Device. (#62)
+-  In ``from_container``, the provided container is compared against the
+   cached version of the device to find discrepancies. This means that
+   modified container objects will always load a new Device.
+   (`#62 <https://github.com/pcdshub/happi/issues/62>`__)
+-  The QSBackend uses newer methods available in the psdm_qs_cli to
+   determine the proposal from the experiment name. This is more robust
+   against exotic experiment naming schemas than prior implementations
+   (`#68 <https://github.com/pcdshub/happi/issues/68>`__)
 
-- The ``QSBackend`` uses newer methods available in the ``psdm_qs_cli`` to
-  determine the proposal from the experiment name. This is more robust against
-  exotic experiment naming schemas than prior implementations (#68)
 
 v1.1.1 (2018-03-08)
 ===================
 
-**Enhancements**
+Enhancements
+------------
 
-- The ``QSBackend`` guesses which a type of motor based on the ``prefix``.
-  Currently this supports ``Newport``, ``IMS``, and ``PMC100`` motors. While there is
-  not an explicit dependency, this will require ``pcdsdevices >= 0.5.0`` to load
-  properly (#51)
+-  The ``QSBackend`` guesses which a type of motor based on the
+   ``prefix``. Currently this supports ``Newport``, ``IMS``, and
+   ``PMC100`` motors. While there is not an explicit dependency, this
+   will require ``pcdsdevices >= 0.5.0`` to load properly
+   (`#51 <https://github.com/pcdshub/happi/issues/51>`__)
 
-**Bug Fixes**
+Bug Fixes
+---------
 
-- Templating is more robust when dealing with types. This includes a fatal case
-  where the default for an ``EntryInfo`` is ``None`` (#50)
+-  Templating is more robust when dealing with types. This includes a
+   fatal case where the default for an ``EntryInfo`` is ``None``
+   (`#50 <https://github.com/pcdshub/happi/issues/50>`__)
+-  A proper error message is returned if an entry in the table does not
+   have the requisite information to load
+   (`#53 <https://github.com/pcdshub/happi/issues/53>`__ )
 
-- A proper error message is returned if an entry in the table does not have the
-  requisite information to load (#53 )
 
 v1.1.0 (2018-02-13)
 ===================
+
 Ownership of this repository has been transferred to
-`<https://github.com/pcdshub>`_
+https://github.com/pcdshub
 
-**Enhancements**
+Enhancements
+------------
 
-- Happi now has a cache so the repeated requests to load the same device do
-  not spawn multiple objects.
+Happi now has a cache so the repeated requests to load the same device
+do not spawn multiple objects.
 
-**Maintenance**
+Maintenance
+-----------
 
-- Cleaner logging messages
+-  Cleaner logging messages
+-  ``QSBackend`` was expanded to accommodate different keyword arguments
+   associated with different authentication methods.
 
-  - ``QSBackend`` was expanded to accommodate different keyword arguments
-     associated with different authentication methods.
+
+v1.0.0 (2018-01-31)
+===================
+
+Enhancements
+------------
+
+-  ``happi`` now handles loading devices with the built-in ``EntryInfo``
+   -> args, kwargs and device_class. Simply enter the proper information
+   in these fields, either directly inputting information or using
+   ``jinja2`` templating. The functions ``from_container`` and
+   ``load_devices`` will then handle the necessary imports and
+   initialize devices for you
+-  Select which backend you want to use with the environment variable
+   ``$HAPPI_BACKEND``
+-  Backend to read from the PCDS Questionnaire
+-  All containers work out of the box with ``pcdsdevices >= 0.3.0`` ##
+   API
+-  All backends are stored in the ``backends`` directory.
+-  The default plugin is now considered to be ``JSONBackend``
+-  The function formerly called ``load_device`` is now ``find_device``.
+
+Build
+-----
+
+-  ``jinja2`` is now a dependency
+-  ``psdm_qs_cli`` is now an optional dependency if you want to use the
+   Questionnaire backend
+-  ``pymongo`` is now an optional dependency if you do not want to use
+   the MongoDB backend
+-  Only tested against Python ``3.5.x`` and ``3.6.x``
+-  Sent to the ``pcds-tag`` and ``pcds-dev`` Anaconda channels instead
+   of the ``skywalker`` channels
+
+
+v0.5.0 (2017-11-11)
+===================
+
+Enhancements
+------------
+
+-  ``happi`` now supports multiple backends. The required database
+   operations are templated in the ``happi.backends.Backend`` The
+   existing mongoDB support was kept as the default, but the an
+   additional JSON backend was added. The choice of database type can be
+   entered as an argument to the ``happi.Client``
+-  Conda builds of ``happi`` are now available at ``skywalker-tag`` and
+   ``skywalker-dev``
+
+Bug Fixes
+---------
+
+-  Devices comparison now works properly. The listed prefix and names
+   are compared.
+
+API Changes
+-----------
+
+-  ``Mirror`` container has been changed to the more specific name
+   ``OffsetMirror``
+
+Deprecations
+------------
+
+-  ``happi`` will no longer support Python 2.7
+
+
+v0.4.0 (2017-04-04)
+===================
+
+Bug Fixes
+---------
+
+-  Removed dependency on mongomock in conda-recipe
+-  ``MockClient`` creates entire ``device_types`` container mapping
+
+API Changes
+-----------
+
+-  Renamed alias -> name, and base -> prefix for Ophyd compatibility
+
+
+v0.3.0 (2017-03-22)
+===================
+
+Enhancements
+------------
+
+-  Added Python 2.7 support
+-  Added macros keyword for EDM support
+-  Added CI tools for Travis, Codecov
+-  Changed tests to use a ``mongomock.MockClient`` instead of an actual
+   mongoDB instance
+-  Device can now ``show_info`` and print a table output of all entered
+   information
+
+Bug Fixes
+---------
+
+-  ``active`` EntryInfo should default to True
+
+API Changes
+-----------
+
+-  Moved the tests directory into the package to make it easily
+   importable by other modules hoping to use a MockClient
+-  Introduced explicit dependencies on ``six``, ``mongomock``, and
+   ``prettytable``


### PR DESCRIPTION
## Description
Docs were broken. This PR fixes the docs to build again and updates the release notes section using https://github.com/pcdshub/pcdsutils/issues/14#issuecomment-630360127 as a tool for it (Thanks, @klauer).

The `autosectionlabel` was a useless extension which was also causing issues with the release notes. I tracked down the instance in which it was being used and replaced it with a regular reference.

## Motivation and Context
Closes #129

## How Has This Been Tested?
Locally

## Where Has This Been Documented?
It is documentation.
