### PR TITLE
MNT: don't error out if one of many devices has a bad entry

### DIFF
--- a/happi/client.py
+++ b/happi/client.py
@@ -384,8 +384,8 @@ class Client(collections.abc.Mapping):
                 result = wrap_cls(client=self, device=self.find_device(**info))
                 results.append(result)
             except Exception:
-                logger.warning(f'Entry for {info["name"]} is malformed. '
-                               'Skipping.')
+                logger.warning('Entry for %s is malformed. Skipping.',
+                               info['name'])
         return results
 
     def search_range(self, key, start, end=None, **kwargs):

--- a/happi/client.py
+++ b/happi/client.py
@@ -384,7 +384,8 @@ class Client(collections.abc.Mapping):
                 result = wrap_cls(client=self, device=self.find_device(**info))
                 results.append(result)
             except Exception:
-                logger.warning(f'Entry for {info["name"]} is malformed. Skipping.')
+                logger.warning(f'Entry for {info["name"]} is malformed. '
+                               'Skipping.')
         return results
 
     def search_range(self, key, start, end=None, **kwargs):

--- a/happi/client.py
+++ b/happi/client.py
@@ -378,8 +378,14 @@ class Client(collections.abc.Mapping):
         Return search results to the user, optionally wrapping with a class
         '''
         wrap_cls = wrap_cls or self._results_wrap_class
-        return [wrap_cls(client=self, device=self.find_device(**info))
-                for info in items]
+        results = []
+        for info in items:
+            try:
+                result = wrap_cls(client=self, device=self.find_device(**info))
+                results.append(result)
+            except Exception:
+                logger.warning(f'Entry for {info["name"]} is malformed. Skipping.')
+        return results
 
     def search_range(self, key, start, end=None, **kwargs):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Wrap the search results in try/except so that one failing device in an `all_devices` call doesn't explode the whole thing.

I'm not sure if this is the best way to fix the problem, but it is a way and it was quick to implement. Maybe this has other negative knock-on effects?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, `typhos <happi-name>` does not work for any device because there is at least one device with a bad entry in lcls's happi config. (There are actually tons of bad entries, but this is irrelevant: https://github.com/pcdshub/device_config/issues/10)

`typhos` has a step where it gets all devices in the database. This fails with a long, confusing traceback about being unable to load the user's device, but this is actually a traceback about failing to load the first device listed in the happi config. This is related to #142.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the tests locally, and they passed, so I didn't break something obvious. I have not yet written a test for this PR.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet
<!--
## Screenshots (if appropriate):
-->
