### PR TITLE
FIX: device_cls string leaking through raising bad exception

### DIFF
--- a/happi/client.py
+++ b/happi/client.py
@@ -1,5 +1,6 @@
 import collections
 import configparser
+import inspect
 import itertools
 import logging
 import os
@@ -203,10 +204,17 @@ class Client(collections.abc.Mapping):
         # If specified by a string
         if device_cls in containers.registry:
             device_cls = containers.registry[device_cls]
+
         # Check that this is a valid HappiItem
-        if not issubclass(device_cls, HappiItem):
-            raise TypeError('{!r} is not a subclass of '
-                            'HappiItem'.format(device_cls))
+        if isinstance(device_cls, str):
+            raise TypeError(
+                f'The device class {device_cls!r} is not in the registry'
+            )
+
+        if (not inspect.isclass(device_cls) or
+                not issubclass(device_cls, HappiItem)):
+            raise TypeError(f'{device_cls!r} is not a subclass of HappiItem')
+
         device = device_cls(**kwargs)
         # Add the method to the device
 


### PR DESCRIPTION
```
(pcds)zlentz@psbuild-rhel7-01:~$ happi search st1k4
[2020-06-09 09:32:10] - WARNING -  Entry for st1k4 is malformed. Skipping.
[2020-06-09 09:32:10] - ERROR -  No devices found
(pcds)zlentz@psbuild-rhel7-01:~$ happi load st1k4
[2020-06-09 09:32:18] - INFO -  Creating shell with devices ['st1k4']
Traceback (most recent call last):
  File "/reg/g/pcds/pyps/apps/dev/pythonpath/happi/client.py", line 272, in find_device
    device = self.create_device(doc['type'], **doc)
  File "/reg/g/pcds/pyps/apps/dev/pythonpath/happi/client.py", line 207, in create_device
    if not issubclass(device_cls, HappiItem):
  File "/reg/g/pcds/pyps/conda/py36/envs/dev/lib/python3.6/abc.py", line 228, in __subclasscheck__
    if issubclass(subclass, scls):
  File "/reg/g/pcds/pyps/conda/py36/envs/dev/lib/python3.6/abc.py", line 232, in __subclasscheck__
    cls._abc_negative_cache.add(subclass)
  File "/reg/g/pcds/pyps/conda/py36/envs/dev/lib/python3.6/_weakrefset.py", line 84, in add
    self.data.add(ref(item, self._remove))
TypeError: cannot create weak reference to 'str' objectThe above exception was the direct cause of the following exception:Traceback (most recent call last):
  File "/reg/g/pcds/pyps/conda/py36/envs/dev/bin/happi", line 11, in <module>
    load_entry_point('happi==1.3.0', 'console_scripts', 'happi')()
  File "/reg/g/pcds/pyps/apps/dev/pythonpath/happi/cli.py", line 185, in main
    happi_cli(sys.argv[1:])
  File "/reg/g/pcds/pyps/apps/dev/pythonpath/happi/cli.py", line 179, in happi_cli
    devices[name] = client.load_device(name=name)
  File "/reg/g/pcds/pyps/apps/dev/pythonpath/happi/client.py", line 308, in load_device
    cntr = self.find_device(**post)
  File "/reg/g/pcds/pyps/apps/dev/pythonpath/happi/client.py", line 277, in find_device
    'corresponding document') from exc
happi.errors.EntryError: The information relating to the device class has been modified to the point where the object can not be initialized, please load the corresponding document
```