### PR TITLE
MNT - change db.json examples to use OphydItem 

### DIFF
--- a/examples/db.json
+++ b/examples/db.json
@@ -1,52 +1,36 @@
 {
-	"TV1L0-VGC-1": {
-		"_id": "TV1L0-VGC-1",
-		"active": true,
-		"args": [],
-		"beamline": "DEMO_BEAMLINE",
-		"creation": "Tue Feb 27 10:41:25 2018",
-		"device_class": "ophyd.sim.SynAxis",
-		"kwargs": {
-			"name": "{{name}}"
-		},
-		"last_edit": "Thu Apr 12 14:40:08 2018",
-		"macros": null,
-		"name": "tv1l0_vgc_1",
-		"parent": null,
-		"prefix": "TV1L0-VGC-1",
-		"screen": null,
-		"stand": "ST1",
-		"system": "Device",
-		"type": "Vacuum",
-		"z": 1035.5,
-		"invalid": true,
-		"functional_group": "Vacuum",
-		"location_group": "S 1"
-	},
-
-	"TV1L0-VGC-2": {
-		"_id": "TV1L0-VGC-2",
-		"active": true,
-		"args": [],
-		"beamline": "DEMO_BEAMLINE",
-		"creation": "Tue Feb 27 10:41:25 2018",
-		"device_class": "ophyd.sim.SynAxis",
-		"kwargs": {
-			"name": "{{name}}"
-		},
-		"last_edit": "Thu Apr 12 14:40:08 2018",
-		"macros": null,
-		"name": "tv1l0_vgc_2",
-		"parent": null,
-		"prefix": "TV1L0-VGC-2",
-		"screen": null,
-		"stand": "ST1",
-		"system": "Device",
-		"type": "Vacuum",
-		"z": 1035.6,
-		"invalid": true,
-		"functional_group": "Vacuum",
-		"location_group": "S 2"
-	}
-
+    "tv1l0_vgc_1": {
+        "_id": "tv1l0_vgc_1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Thu Jul 23 17:05:48 2020",
+        "device_class": "ophyd.sim.SynAxis",
+        "documentation": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Jul 23 17:05:48 2020",
+        "name": "tv1l0_vgc_1",
+        "prefix": "TV1L0-VGC-1",
+        "type": "OphydItem"
+    },
+    "tv1l0_vgc_2": {
+        "_id": "tv1l0_vgc_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Thu Jul 23 17:06:44 2020",
+        "device_class": "ophyd.im.SynAxis",
+        "documentation": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Jul 23 17:06:44 2020",
+        "name": "tv1l0_vgc_2",
+        "prefix": "TV1L0-VGC-2",
+        "type": "OphydItem"
+    }
 }

--- a/examples/db.json
+++ b/examples/db.json
@@ -23,7 +23,7 @@
             "{{prefix}}"
         ],
         "creation": "Thu Jul 23 17:06:44 2020",
-        "device_class": "ophyd.im.SynAxis",
+        "device_class": "ophyd.sim.SynAxis",
         "documentation": null,
         "kwargs": {
             "name": "{{name}}"

--- a/examples/qt/listview.py
+++ b/examples/qt/listview.py
@@ -31,9 +31,10 @@ if __name__ == "__main__":
     file_path = pathlib.Path(__file__).resolve()
     db_path = file_path.parent.parent / "db.json"
     cli = happi.Client(path=db_path)
+    
     w = HappiDeviceExplorer()
     w.view.client = cli
-    w.view.search(beamline="DEMO_BEAMLINE")
+    w.view.search(type='OphydItem')
     w.show()
 
     app.exec_()

--- a/examples/qt/treeview.py
+++ b/examples/qt/treeview.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     cli = happi.Client(path=db_path)
     w = HappiDeviceExplorer()
     w.view.client = cli
-    w.view.search(active=True)
+    w.view.search(type='OphydItem')
     w.show()
 
     app.exec_()

--- a/examples/qt/treeview.py
+++ b/examples/qt/treeview.py
@@ -7,8 +7,8 @@ import happi.qt
 
 class HappiDeviceExplorer(QtWidgets.QFrame):
     _GROUP_KEYS = {'Name': 'name',
-                   'Function': 'functional_group',
-                   'Location': 'location_group'}
+                   'Type': 'type',
+                   'Device Class': 'device_class'}
 
     def __init__(self, parent=None):
         super(HappiDeviceExplorer, self).__init__(parent=parent)
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     cli = happi.Client(path=db_path)
     w = HappiDeviceExplorer()
     w.view.client = cli
-    w.view.search(beamline="DEMO_BEAMLINE")
+    w.view.search(active=True)
     w.show()
 
     app.exec_()

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -52,7 +52,7 @@ class HappiViewMixin(object):
 
     @staticmethod
     def create_item(entry):
-        itm = QtGui.QStandardItem(entry.item.name)
+        itm = QtGui.QStandardItem(entry.name)
         itm.setData(entry)
         itm.setFlags(itm.flags() & ~QtCore.Qt.ItemIsEditable)
         return itm
@@ -100,7 +100,7 @@ class HappiDeviceListView(QtWidgets.QListView, HappiViewMixin):
         """
         if not self.entries():
             return
-        items = [self.create_item(entry) for entry in self.entries()]
+        items = [self.create_item(entry.item) for entry in self.entries()]
 
         self.model.clear()
 
@@ -134,7 +134,7 @@ class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
 
         self.proxy_model = QtCore.QSortFilterProxyModel()
         self.proxy_model.setFilterKeyColumn(-1)
-       # self.proxy_model.setRecursiveFilteringEnabled(True)
+        self.proxy_model.setRecursiveFilteringEnabled(True)
         self.proxy_model.setDynamicSortFilter(True)
         self.setModel(self.proxy_model)
 
@@ -187,8 +187,8 @@ class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
 
         for entry in self.entries():
             try:
-                field_val = get_happi_entry_value(entry, field)
-                entry_group[field_val].append(entry)
+                field_val = get_happi_entry_value(entry.item, field)
+                entry_group[field_val].append(entry.item)
             except ValueError:
                 logger.exception(
                     'Could not retrieve value for field %s at entry %s',

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -52,7 +52,7 @@ class HappiViewMixin(object):
 
     @staticmethod
     def create_item(entry):
-        itm = QtGui.QStandardItem(entry.name)
+        itm = QtGui.QStandardItem(entry.item.name)
         itm.setData(entry)
         itm.setFlags(itm.flags() & ~QtCore.Qt.ItemIsEditable)
         return itm
@@ -134,7 +134,7 @@ class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
 
         self.proxy_model = QtCore.QSortFilterProxyModel()
         self.proxy_model.setFilterKeyColumn(-1)
-        self.proxy_model.setRecursiveFilteringEnabled(True)
+       # self.proxy_model.setRecursiveFilteringEnabled(True)
         self.proxy_model.setDynamicSortFilter(True)
         self.setModel(self.proxy_model)
 

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -11,7 +11,7 @@ def create_alias(name):
 
 
 def get_happi_entry_value(entry, key, search_extraneous=True):
-    extraneous = entry.extraneous
+    extraneous = entry.item.extraneous
     value = getattr(entry, key, None)
     if value is None and search_extraneous:
         # Try to look at extraneous

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -11,7 +11,7 @@ def create_alias(name):
 
 
 def get_happi_entry_value(entry, key, search_extraneous=True):
-    extraneous = entry.item.extraneous
+    extraneous = entry.extraneous
     value = getattr(entry, key, None)
     if value is None and search_extraneous:
         # Try to look at extraneous


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- Have removed the previous two devices from `happi/examples/db.json` and added two `OphydItem` items instead (they are using the same names and prefixes as the previous ones)
- Have changed the `happi/happi/qt/model.py` to pass in `entry.item` instead of `entry` when creating an item, and when using the `get_happi_entry_value` function


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The example had to be reworked to use OphydItem instead and be standalone.
closes #150 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Check to see if it validates:
```
>>> client = happi.Client(path='./examples/db.json')
>>> client.validate()
[]
```
Run the `listview.py` and `treeview.py` widgets to see the items

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This has not been documented
<!--
## Screenshots (if appropriate):
-->
