### PR TITLE
DOC: Add documentation for cli

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ mongomock
 sphinx
 sphinx_rtd_theme
 psdm_qs_cli
+sphinx-argparse

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,8 @@
+===================================
+Command Line Utilities
+===================================
+
+.. argparse::
+   :module: happi.cli
+   :func: get_parser
+   :prog: happi

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.todo',
               'sphinx.ext.napoleon',
               'sphinx.ext.autosummary',
+              'sphinxarg.ext',
               'IPython.sphinxext.ipython_directive',
               'IPython.sphinxext.ipython_console_highlighting'
               ]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ there are still standards within the group we need to uphold.
    client_api.rst
    backends.rst
    containers.rst
+   cli.rst
 
 .. toctree::
    :maxdepth: 0

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -15,42 +15,51 @@ import happi
 
 logger = logging.getLogger(__name__)
 
-# Argument Parser Setup
-parser = argparse.ArgumentParser(description='happi command line tool')
 
-# Optional args general to all happi operations
-parser.add_argument('--path', type=str,
-                    help='path to happi configuration file')
-parser.add_argument('--verbose', '-v', action='store_true',
-                    help='Show the degub logging stream')
-parser.add_argument('--version', '-V', action='store_true',
-                    help='Current version and location '
-                    'of Happi installation.')
-# Subparser to trigger search arguments
-subparsers = parser.add_subparsers(help='Subparsers to search, add, edit',
-                                   dest='cmd')
-parser_search = subparsers.add_parser('search', help='Search the happi '
-                                      'database')
-parser_search.add_argument('search_criteria', nargs='+',
-                           help='Search criteria: field=value. If field= is '
-                                'omitted, it will be assumed to be "name". '
-                                'You may include as many search criteria as '
-                                'you like.')
-parser_add = subparsers.add_parser('add', help='Add new entries')
-parser_add.add_argument('--clone', default='',
-                        help='Name of device to use for default parameters')
-parser_edit = subparsers.add_parser('edit', help='Change existing entry')
-parser_edit.add_argument('name', help='Device to edit')
-parser_edit.add_argument('edits', nargs='+',
-                         help='Edits of the form field=value')
-parser_load = subparsers.add_parser('load',
-                                    help='Open IPython terminal with '
-                                         'device loaded')
-parser_load.add_argument('device_names', nargs='+',
-                         help='Devices to load')
+def get_parser():
+    """
+    Defines HAPPI shell commands
+    """
+    # Argument Parser Setup
+    parser = argparse.ArgumentParser(description='happi command line tool')
+
+    # Optional args general to all happi operations
+    parser.add_argument('--path', type=str,
+                        help='path to happi configuration file')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Show the degub logging stream')
+    parser.add_argument('--version', '-V', action='store_true',
+                        help='Current version and location '
+                        'of Happi installation.')
+    # Subparser to trigger search arguments
+    subparsers = parser.add_subparsers(help='Subparsers to search, add, edit',
+                                       dest='cmd')
+    parser_search = subparsers.add_parser('search', help='Search the happi '
+                                          'database')
+    parser_search.add_argument('search_criteria', nargs='+',
+                               help='Search criteria: '
+                               'field=value. If field= is '
+                               'omitted, it will be assumed to be "name". '
+                               'You may include as many search criteria as '
+                               'you like.')
+    parser_add = subparsers.add_parser('add', help='Add new entries')
+    parser_add.add_argument('--clone', default='',
+                            help='Name of device to use for default parameters'
+                            )
+    parser_edit = subparsers.add_parser('edit', help='Change existing entry')
+    parser_edit.add_argument('name', help='Device to edit')
+    parser_edit.add_argument('edits', nargs='+',
+                             help='Edits of the form field=value')
+    parser_load = subparsers.add_parser('load',
+                                        help='Open IPython terminal with '
+                                        'device loaded')
+    parser_load.add_argument('device_names', nargs='+',
+                             help='Devices to load')
+    return parser
 
 
 def happi_cli(args):
+    parser = get_parser()
     args = parser.parse_args(args)
 
     # Logging Level handling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- I have added a new .rst file under the `/docs/source/` folder called `cli.rst` that uses the **argparse** directive `..argparse::` which automagically generates the documentation for the command line arguments
- I have added a new dependency: `sphinx-argparse` in `dev-requirements` 
- Enabled the extension `sphinxarg.ext` in the sphinx config file
- Changed cli.py file so that we have a function that returns the parser (needed for the `..argparse::` directive) - just encapsulated the parser's lines from `cli.py` into a function called `get_parser`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to provide users with documentation about Happi's Command Line Utilities
closes #135 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
cd docs
make html
firefox build/html/index.html
```
This generates the HTML documentation for HAPPI at the `/docs/build/html` folder. 
Locate the `index.html` file and open it with your browser - you should see below the `API Documentation` a section that represents the `Command Line Utilities` 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Under the `API Documentation` section
<!--
## Screenshots (if appropriate):
-->
![cli](https://user-images.githubusercontent.com/62306310/88706843-4486ac00-d0c6-11ea-909c-0c25aaaceff5.PNG)
