### PR TITLE
FIX: fix silent fail when editing a nonexisting field

### DIFF
--- a/happi/cli.py
+++ b/happi/cli.py
@@ -174,7 +174,7 @@ def happi_cli(args):
                 setattr(device, field, value)
             except Exception:
                 is_invalid_field = True
-                logger.error(f'Could not edit {args.name}.{field}: {ex}')
+                logger.error('Could not edit %s.%s', args.name, field)
         if is_invalid_field:
             sys.exit(1)
         device.save()

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -170,7 +170,7 @@ def happi_cli(args):
             field, value = edit.split('=', 1)
             try:
                 getattr(device, field)
-                logger.info(f'Setting {args.name}.{field} = {value}')
+                logger.info('Setting %s.%s = %s', args.name, field, value)
                 setattr(device, field, value)
             except Exception:
                 is_invalid_field = True

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -165,11 +165,18 @@ def happi_cli(args):
     elif args.cmd == 'edit':
         logger.debug('Starting edit block')
         device = client.find_device(name=args.name)
+        is_edited = False
         for edit in args.edits:
             field, value = edit.split('=', 1)
-            logger.info(f'Setting {args.name}.{field} = {value}')
-            setattr(device, field, value)
-        device.save()
+            try:
+                getattr(device, field)
+                logger.info(f'Setting {args.name}.{field} = {value}')
+                setattr(device, field, value)
+                is_edited = True
+            except AttributeError as ex:
+                logger.warning(f'Could not edit {args.name}.{field}: {ex}')
+        if is_edited:
+            device.save()
         device.show_info()
     elif args.cmd == 'load':
         logger.debug('Starting load block')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -172,9 +172,9 @@ def happi_cli(args):
                 getattr(device, field)
                 logger.info('Setting %s.%s = %s', args.name, field, value)
                 setattr(device, field, value)
-            except Exception:
+            except Exception as e:
                 is_invalid_field = True
-                logger.error('Could not edit %s.%s', args.name, field)
+                logger.error('Could not edit %s.%s: %s', args.name, field, e)
         if is_invalid_field:
             sys.exit(1)
         device.save()

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -172,7 +172,7 @@ def happi_cli(args):
                 getattr(device, field)
                 logger.info(f'Setting {args.name}.{field} = {value}')
                 setattr(device, field, value)
-            except AttributeError as ex:
+            except Exception:
                 is_invalid_field = True
                 logger.error(f'Could not edit {args.name}.{field}: {ex}')
         if is_invalid_field:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -165,18 +165,19 @@ def happi_cli(args):
     elif args.cmd == 'edit':
         logger.debug('Starting edit block')
         device = client.find_device(name=args.name)
-        is_edited = False
+        is_invalid_field = False
         for edit in args.edits:
             field, value = edit.split('=', 1)
             try:
                 getattr(device, field)
                 logger.info(f'Setting {args.name}.{field} = {value}')
                 setattr(device, field, value)
-                is_edited = True
             except AttributeError as ex:
-                logger.warning(f'Could not edit {args.name}.{field}: {ex}')
-        if is_edited:
-            device.save()
+                is_invalid_field = True
+                logger.error(f'Could not edit {args.name}.{field}: {ex}')
+        if is_invalid_field:
+            sys.exit(1)
+        device.save()
         device.show_info()
     elif args.cmd == 'load':
         logger.debug('Starting load block')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- I modified `/happi/cli.py` to try to `getattr` when parsing the `edit` argument before setting the object's attribute. If this fails, it logs and error message about the field that was not successfully set. 
- If we try to set any invalid fields, then we exit the process 
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to warn the users when they are trying to edit a non-existing field for a device
We also want to exit the process if any invalid information is detected to keep the integrity of the database 
trying to close #147 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with a dummy db.json file 

Test with two fields that fail and one that succeeds: 
`happi edit my_name_here beamline=my_beamline stand=my_stand prefix=my_prefix`
Test with single field that succeeds:
`happi edit my_name_here prefix=my_prefix`


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Nowhere 
<!--
## Screenshots (if appropriate):
-->
![silent_fail4](https://user-images.githubusercontent.com/62306310/88730114-364a8700-d0ea-11ea-8ede-c5df8d25018c.PNG)


