### PR TITLE
Cli search regex

### DIFF
--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -228,7 +228,7 @@ class JSONBackend(_Backend):
             Requested information, where the values are regular expressions.
         """
         def comparison(name, doc):
-            return regexes and all(key in doc and regex.match(doc[key])
+            return regexes and all(key in doc and regex.match(str(doc[key]))
                                    for key, regex in regexes.items())
 
         regexes = {

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -107,8 +107,6 @@ def happi_cli(args):
                 logger.debug('Changed %s to float', value)
                 value = str(float(value))
 
-            # maybe don't check for z - not all of them have z?
-            # but could other fields have a comma? - i think they might
             if criteria == 'z' and ',' in value:
                 start = None
                 end = None
@@ -120,7 +118,7 @@ def happi_cli(args):
                     end = float(end)
                 except Exception as ex:
                     logger.error("Invalid numbers for the z range %s", ex)
-                    sys.exit()
+                    sys.exit(1)
                 if start < end:
                     results += client.search_range('z', start, end)
                 else:
@@ -136,11 +134,11 @@ def happi_cli(args):
         results += client.search_regex(**client_args)
 
         # find the repeated items
-        _size = len(results)
+        res_size = len(results)
         repeated = []
-        for i in range(_size):
+        for i in range(res_size):
             k = i + 1
-            for j in range(k, _size):
+            for j in range(k, res_size):
                 if results[i] == results[j] and results[i] not in repeated:
                     repeated.append(results[i])
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -11,6 +11,7 @@ import sys
 
 import coloredlogs
 from IPython import start_ipython
+from .utils import is_a_range
 
 import happi
 
@@ -109,22 +110,15 @@ def happi_cli(args):
                 logger.debug('Changed %s to float', value)
                 value = str(float(value))
 
-            if (value.replace('.', '').replace(',', '').isnumeric()
-                    and ',' in value):
-                start = None
-                end = None
-                try:
-                    start, end = value.split(',')
-                    start = float(start)
-                    end = float(end)
-                    is_range = True
-                except Exception as ex:
-                    logger.error("Invalid numbers for the range %s", ex)
-                    sys.exit(1)
-                if start < end:
-                    range_list = client.search_range(criteria, start, end)
+            if is_a_range(value):
+                start, stop = value.split(',')
+                start = float(start)
+                stop = float(stop)
+                is_range = True
+                if start < stop:
+                    range_list = client.search_range(criteria, start, stop)
                 else:
-                    logger.error('Invalid range')
+                    logger.error('Invalid range, make sure start < stop')
 
             # skip the criteria for range values
             # it won't be a valid criteria for search_regex()

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -114,11 +114,11 @@ def happi_cli(args):
                     and ',' in value):
                 start = None
                 end = None
-                is_range = True
                 try:
                     start, end = value.split(',')
                     start = float(start)
                     end = float(end)
+                    is_range = True
                 except Exception as ex:
                     logger.error("Invalid numbers for the range %s", ex)
                     sys.exit(1)

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -105,6 +105,9 @@ def happi_cli(args):
                     criteria, value, client_args[criteria]
                 )
                 return
+            if value.replace('.', '').isnumeric():
+                logger.debug('Changed %s to float', value)
+                value = str(float(value))
             if criteria == 'z' and ',' in value:
                 start = None
                 end = None

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -89,7 +89,6 @@ def happi_cli(args):
 
         # Get search criteria into dictionary for use by client
         client_args = {}
-        results = []
         range_list = []
         regex_list = []
         is_range = False
@@ -146,7 +145,7 @@ def happi_cli(args):
                 if results[i] == results[j] and results[i] not in repeated:
                     repeated.append(results[i])
 
-        # we only want to return the ones that have been repeated
+        # we only want to return the ones that have been repeated when
         # they have been matched with both search_regex() & search_range()
         if repeated:
             for res in repeated:

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -81,7 +81,7 @@ def test_cli_version(capsys):
 
 def test_search(happi_cfg):
     client = happi.client.Client.from_config(cfg=happi_cfg)
-    res = client.search(beamline="TST")
+    res = client.search_regex(beamline="TST")
     res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
                                    'beamline=TST'])
     assert [r.device for r in res] == [r.device for r in res_cli]
@@ -89,7 +89,15 @@ def test_search(happi_cfg):
 
 def test_search_z(happi_cfg):
     client = happi.client.Client.from_config(cfg=happi_cfg)
-    res = client.search(z=6.0)
+    res = client.search_regex(z="6.0")
     res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
                                    'z=6.0'])
+    assert [r.device for r in res] == [r.device for r in res_cli]
+
+
+def test_search_z_range(happi_cfg):
+    client = happi.client.Client.from_config(cfg=happi_cfg)
+    res = client.search_range('z', 3.0, 6.0)
+    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
+                                   'z=[3.0,6.0]'])
     assert [r.device for r in res] == [r.device for r in res_cli]

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -99,5 +99,5 @@ def test_search_z_range(happi_cfg):
     client = happi.client.Client.from_config(cfg=happi_cfg)
     res = client.search_range('z', 3.0, 6.0)
     res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
-                                   'z=[3.0,6.0]'])
+                                   'z=3.0,6.0'])
     assert [r.device for r in res] == [r.device for r in res_cli]

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -1,6 +1,9 @@
 """
 Basic module utilities
 """
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def create_alias(name):
@@ -20,3 +23,31 @@ def get_happi_entry_value(entry, key, search_extraneous=True):
     if not value:
         raise ValueError('Invalid Key for Device.')
     return value
+
+
+def is_number(str_value):
+    """
+    Checks if it is a valid float number
+    """
+    try:
+        float(str_value)
+        return True
+    except ValueError:
+        return False
+
+
+def is_a_range(str_value):
+    """
+    Checks to see if it is a range.
+    It needs to have two valid values separated by a comma.
+    Ex:
+        1,100
+        -2,8
+        100,2
+    """
+    if ',' in str_value:
+        start, stop = str_value.split(',')
+        if is_number(start) and is_number(stop):
+            return True
+        else:
+            logger.error("Possibly provided invalid numbers for a range")

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -51,3 +51,4 @@ def is_a_range(str_value):
             return True
         else:
             logger.error("Possibly provided invalid numbers for a range")
+            return False

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -52,3 +52,5 @@ def is_a_range(str_value):
         else:
             logger.error("Possibly provided invalid numbers for a range")
             return False
+    else:
+        return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- ` happi search` command line has been modified to use `search_regex` and `search_range` (for z values) instead of the previous `search` function. 

## Motivation and Context
- this change will allow the user to search using the asterisk symbol `*` that matches 0 or more occurrences.
    ex: `*kmono*` will match any occurances that have `kmono` in them
- this also allows the user to search for a range of `z` values by typing a valid range separated by comma like so:
  - z=0,89
**Note:** there is no space between the values

<!--- If it fixes an open issue, please link to the issue here. -->
Intended to close #141 
Will possible close #144 as well

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has only been tested locally with items from a dummy json database. 
**Has Not been tested with a mongo database!!** 

**Ex:**
- `happi search z=1,5`
```+--------------------+-------------------------------------+
| EntryInfo          | Value                               |
+--------------------+-------------------------------------+
| active             | True                                |
| args               | ['{{prefix}}']                      |
| beamline           | the_beamline                        |
| creation           | Thu Jul 30 21:48:19 2020            |
| detailed_screen    | None                                |
| device_class       | class                               |
| documentation      | None                                |
| embedded_screen    | None                                |
| engineering_screen | None                                |
| functional_group   | my_func_group                       |
| kwargs             | {'name': '{{name}}'}                |
| last_edit          | Thu Jul 30 23:27:50 2020            |
| lightpath          | False                               |
| location_group     | group                               |
| macros             | None                                |
| name               | the_vacum                           |
| parent             | None                                |
| prefix             | my_prefix                           |
| stand              | None                                |
| system             | vacuum                              |
| type               | pcdsdevices.happi.containers.Vacuum |
| z                  |  4.30000                            |
+--------------------+-------------------------------------+ 
```

- `happi search name=*motor* `

```
+--------------------+------------------------------------+
| EntryInfo          | Value                              |
+--------------------+------------------------------------+
| active             | True                               |
| args               | ['{{prefix}}']                     |
| beamline           | motor_beamline                     |
| creation           | Sun Aug  2 23:07:16 2020           |
| detailed_screen    | motor_screen                       |
| device_class       | motor_clss                         |
| documentation      | docs for motor                     |
| embedded_screen    | motor_embeded_Screen               |
| engineering_screen | motor_engineering_screen           |
| functional_group   | motor_func_group                   |
| kwargs             | {'name': '{{name}}'}               |
| last_edit          | Sun Aug  2 23:07:16 2020           |
| lightpath          | True                               |
| location_group     | motor_group                        |
| macros             | m1                                 |
| name               | motor_name                         |
| parent             | motor_parent                       |
| prefix             | motor_prefi                        |
| stand              | DG1                                |
| system             | motor_system                       |
| type               | pcdsdevices.happi.containers.Motor |
| z                  | 89.00000                           |
+--------------------+------------------------------------+
```
- `happi search name=*name* z=1,90`

```
+--------------------+------------------------------------+
| EntryInfo          | Value                              |
+--------------------+------------------------------------+
| active             | True                               |
| args               | ['{{prefix}}']                     |
| beamline           | motor_beamline                     |
| creation           | Sun Aug  2 23:07:16 2020           |
| detailed_screen    | motor_screen                       |
| device_class       | motor_clss                         |
| documentation      | docs for motor                     |
| embedded_screen    | motor_embeded_Screen               |
| engineering_screen | motor_engineering_screen           |
| functional_group   | motor_func_group                   |
| kwargs             | {'name': '{{name}}'}               |
| last_edit          | Sun Aug  2 23:07:16 2020           |
| lightpath          | True                               |
| location_group     | motor_group                        |
| macros             | m1                                 |
| name               | motor_name                         |
| parent             | motor_parent                       |
| prefix             | motor_prefi                        |
| stand              | DG1                                |
| system             | motor_system                       |
| type               | pcdsdevices.happi.containers.Motor |
| z                  | 89.00000                           |
+--------------------+------------------------------------+
+--------------------+------------------------------------------------------+
| EntryInfo          | Value                                                |
+--------------------+------------------------------------------------------+
| active             | True                                                 |
| args               | ['{{prefix}}']                                       |
| beamline           | pim_beamline                                         |
| creation           | Tue Aug 11 17:03:51 2020                             |
| data               | None                                                 |
| detailed_screen    | None                                                 |
| device_class       | pim_device_class                                     |
| documentation      | None                                                 |
| embedded_screen    | None                                                 |
| engineering_screen | None                                                 |
| functional_group   | pim_func_group                                       |
| kwargs             | {'name': '{{name}}', 'prefix_det': '{{prefix_det}}'} |
| last_edit          | Tue Aug 11 17:03:51 2020                             |
| lightpath          | False                                                |
| location_group     | pim_bamline                                          |
| macros             | None                                                 |
| name               | pim_name                                             |
| parent             | None                                                 |
| prefix             | PIM:IOC                                              |
| prefix_det         | None                                                 |
| stand              | AA9                                                  |
| system             | diagnostic                                           |
| type               | pcdsdevices.happi.containers.PIM                     |
| z                  | 89.34000                                             |
+--------------------+------------------------------------------------------+
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
