### PR TITLE
ENH: Output usage without subcommands

### DIFF
--- a/happi/cli.py
+++ b/happi/cli.py
@@ -64,7 +64,7 @@ def happi_cli(args):
     parser = get_parser()
     args = parser.parse_args(args)
 
-    # print how to use happi if no argument provided
+    # print happi usage if no arguments are provided
     if len(sys.argv) == 1:
         parser.print_usage()
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -62,12 +62,11 @@ def get_parser():
 
 def happi_cli(args):
     parser = get_parser()
-    args = parser.parse_args(args)
-
     # print happi usage if no arguments are provided
-    if len(sys.argv) == 1:
+    if not args:
         parser.print_usage()
         return
+    args = parser.parse_args(args)
 
     # Logging Level handling
     if args.verbose:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -67,6 +67,7 @@ def happi_cli(args):
     # print happi usage if no arguments are provided
     if len(sys.argv) == 1:
         parser.print_usage()
+        sys.exit(0)
 
     # Logging Level handling
     if args.verbose:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -67,7 +67,7 @@ def happi_cli(args):
     # print happi usage if no arguments are provided
     if len(sys.argv) == 1:
         parser.print_usage()
-        sys.exit(0)
+        return
 
     # Logging Level handling
     if args.verbose:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -64,6 +64,10 @@ def happi_cli(args):
     parser = get_parser()
     args = parser.parse_args(args)
 
+    # print how to use happi if no argument provided
+    if len(sys.argv) == 1:
+        parser.print_usage()
+
     # Logging Level handling
     if args.verbose:
         shown_logger = logging.getLogger()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Using `len(sys.argv)` to count the arguments passed to happi, and printing the happi usage if only one argument is passed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows the user to see what commands are available when only `happi` is typed without any sub commands. 
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to close #154 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been tested locally only: 
```
(python3.7) $ happi
usage: happi [-h] [--path PATH] [--verbose] [--version]
             {search,add,edit,load} ...
```
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
