### PR TITLE
FIX: fix typo in cli.py for clone command

### DIFF
--- a/happi/cli.py
+++ b/happi/cli.py
@@ -163,7 +163,7 @@ def happi_cli(args):
         if args.clone:
             clone_source = client.find_device(name=args.clone)
             # Must use the same container if cloning
-            response = registry.entry_from_class(clone_source.__class__)
+            response = registry.entry_for_class(clone_source.__class__)
         else:
             # Keep Device at registry for backwards compatibility but filter
             # it out of new devices options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
It turns out there was just a simple typo when calling a function from `HappiRegistry`. It might have been that the function itself was changed after the clone was added, maybe not... 
So this PR fixed this typo and now the `clone` command seems to work fine. 
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was necessary to make the `clone` command work. 
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to close #156 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Has been tested locally with a dummy json database: 
Trying cloning **`an_item`**:
```
happi add --clone an_item

[2020-08-19 09:45:36] - INFO -  Enter value for name, default=an_item, enforce=re.compile('[a-z][a-z\\_0-9]{2,78}$')
an_item_2
[2020-08-19 09:45:45] - INFO -  Enter value for device_class, default=class, enforce=<class 'str'>

[2020-08-19 09:45:48] - INFO -  Selecting default value class
[2020-08-19 09:45:48] - INFO -  Enter value for args, default=['{{prefix}}'], enforce=<class 'list'>

[2020-08-19 09:45:49] - INFO -  Selecting default value ['{{prefix}}']
[2020-08-19 09:45:49] - INFO -  Enter value for kwargs, default={'name': '{{name}}'}, enforce=<class 'dict'>

[2020-08-19 09:45:50] - INFO -  Selecting default value {'name': '{{name}}'}
[2020-08-19 09:45:50] - INFO -  Enter value for active, default=True, enforce=<class 'bool'>

[2020-08-19 09:45:51] - INFO -  Selecting default value True
[2020-08-19 09:45:51] - INFO -  Enter value for documentation, default=None, enforce=<class 'str'>

[2020-08-19 09:45:52] - INFO -  Selecting default value None
[2020-08-19 09:45:52] - INFO -  Enter value for prefix, default=PREFIX, enforce=<class 'str'>

[2020-08-19 09:45:53] - INFO -  Selecting default value PREFIX
[2020-08-19 09:45:53] - INFO -  Please confirm the following info is correct:
+---------------+----------------------+
| EntryInfo     | Value                |
+---------------+----------------------+
| active        | True                 |
| args          | ['{{prefix}}']       |
| device_class  | class                |
| documentation | None                 |
| kwargs        | {'name': '{{name}}'} |
| name          | an_item_2            |
| prefix        | PREFIX               |
+---------------+----------------------+
y/N
y
[2020-08-19 09:45:58] - INFO -  Adding device
[2020-08-19 09:45:58] - INFO -  Storing device OphydItem (name=an_item_2) ...
[2020-08-19 09:45:58] - INFO -  Adding / Modifying information for an_item_2 ...
[2020-08-19 09:45:58] - INFO -  HappiItem OphydItem (name=an_item_2) has been succesfully added to the database
```

Contents of database after this change: 
```
    "an_item": {
        "_id": "an_item",
        "active": true,
        "args": [
            "{{prefix}}"
        ],
        "creation": "Thu Aug 13 00:28:59 2020",
        "device_class": "class",
        "documentation": null,
        "kwargs": {
            "name": "{{name}}"
        },
        "last_edit": "Mon Aug 17 15:45:15 2020",
        "name": "an_item",
        "prefix": "PREFIX",
        "type": "OphydItem"
    },
    "an_item_2": {
        "_id": "an_item_2",
        "active": true,
        "args": [
            "{{prefix}}"
        ],
        "creation": "Wed Aug 19 09:45:58 2020",
        "device_class": "class",
        "documentation": null,
        "kwargs": {
            "name": "{{name}}"
        },
        "last_edit": "Wed Aug 19 09:45:58 2020",
        "name": "an_item_2",
        "prefix": "PREFIX",
        "type": "OphydItem"
    },
```
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
