### PR TITLE
When malformed, make warning more informative

### DIFF
--- a/happi/client.py
+++ b/happi/client.py
@@ -391,9 +391,9 @@ class Client(collections.abc.Mapping):
             try:
                 result = wrap_cls(client=self, device=self.find_device(**info))
                 results.append(result)
-            except Exception:
-                logger.warning('Entry for %s is malformed. Skipping.',
-                               info['name'])
+            except Exception as exc:
+                logger.warning('Entry for %s is malformed (%s). Skipping.',
+                               info['name'], str(exc))
         return results
 
     def search_range(self, key, start, end=None, **kwargs):

--- a/happi/client.py
+++ b/happi/client.py
@@ -393,7 +393,7 @@ class Client(collections.abc.Mapping):
                 results.append(result)
             except Exception as exc:
                 logger.warning('Entry for %s is malformed (%s). Skipping.',
-                               info['name'], str(exc))
+                               info['name'], exc)
         return results
 
     def search_range(self, key, start, end=None, **kwargs):


### PR DESCRIPTION
## Description
Add exception message to warning when entry is malformed.

## Motivation and Context
While trying to learn happi.loader, the terse message did not inform what, exactly, was wrong.  With the exception text, learned that `name` attribute (in JSON file) must be at least three characters and must not have uppercase.

## How Has This Been Tested?

with

```json
{
  "m1": {
    "active": true,
    "documentation": null,
    "args": [
      "{{prefix}}"
    ],
    "kwargs": {
      "name": "{{name}}"
    },
    "type": "OphydItem",
    "_id": "pinhole",
    "device_class": "ophyd.EpicsMotor",
    "name": "sky_M1",
    "prefix": "sky:m1"
  }
}
```

shows

```
WARNING:happi.client:Entry for sky_M1 is malformed (name='sky_M1' did not match the enforced pattern[a-z][a-z\_0-9]{2,78}$). Skipping.
```

## Where Has This Been Documented?
see proposed changes