### PR TITLE
ENH: bash/fzf-based fuzzy finding of happi items

### DIFF
--- a/conda-recipe/activate.sh
+++ b/conda-recipe/activate.sh
@@ -1,0 +1,17 @@
+# This activates fzf-based fuzzy finding for happi searches.
+# This is meant to be sourced from bash.
+
+_fzf_complete_happi() {
+  _fzf_complete --multi --reverse --prompt="happi> " -- "$@" < <(
+    python `which happi` search '*' --json 2>/dev/null |python -c '
+import json
+import sys
+items = json.load(sys.stdin)
+for item in items:
+    print(item["name"])
+'
+
+  )
+}
+
+[ -n "$BASH" ] && complete -F _fzf_complete_happi -o default -o bashdefault happi

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,1 +1,13 @@
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+
+ACTIVATE=$PREFIX/etc/conda/activate.d/happi
+DEACTIVATE=$PREFIX/etc/conda/deactivate.d/happi
+
+cp -f conda-recipe/activate.sh ${ACTIVATE}.sh
+cp -f conda-recipe/deactivate.sh ${DEACTIVATE}.sh
+
+unset ACTIVATE
+unset DEACTIVATE

--- a/conda-recipe/deactivate.sh
+++ b/conda-recipe/deactivate.sh
@@ -1,0 +1,6 @@
+# This deactivates fzf-based fuzzy finding for happi searches.
+# This is meant to be sourced from bash.
+
+[ -n "$BASH" ] && complete -r happi
+
+unset _fzf_complete_happi

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -5,6 +5,7 @@ This module defines the ``happi`` command line utility
 
 import argparse
 import fnmatch
+import json
 import logging
 import os
 import sys
@@ -38,6 +39,8 @@ def get_parser():
                                        dest='cmd')
     parser_search = subparsers.add_parser('search', help='Search the happi '
                                           'database')
+    parser_search.add_argument('--json', action='store_true',
+                               help='Show results as JSON')
     parser_search.add_argument('search_criteria', nargs='+',
                                help='Search criteria: '
                                'field=value. If field= is '
@@ -146,21 +149,26 @@ def happi_cli(args):
         # we only want to return the ones that have been repeated when
         # they have been matched with both search_regex() & search_range()
         if repeated:
-            for res in repeated:
-                res.item.show_info()
-            return repeated
-        # only matched with search_regex()
+            final_results = repeated
         elif regex_list and not is_range:
-            for res in regex_list:
-                res.item.show_info()
-            return regex_list
-        # only matched with search_range()
+            # only matched with search_regex()
+            final_results = regex_list
         elif range_list and is_range:
-            for res in range_list:
-                res.item.show_info()
-            return range_list
+            # only matched with search_range()
+            final_results = range_list
         else:
+            final_results = []
+
+        if args.json:
+            json.dump([dict(res.item) for res in final_results], indent=2,
+                      fp=sys.stdout)
+        else:
+            for res in final_results:
+                res.item.show_info()
+
+        if not final_results:
             logger.error('No devices found')
+        return final_results
     elif args.cmd == 'add':
         logger.debug('Starting interactive add')
         registry = happi.containers.registry

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1,7 +1,6 @@
 """
 This module defines the ``happi`` command line utility
 """
-# cli.py
 
 import argparse
 import fnmatch
@@ -11,7 +10,6 @@ import os
 import sys
 
 import coloredlogs
-from IPython import start_ipython
 from .utils import is_a_range
 
 import happi
@@ -251,6 +249,8 @@ def happi_cli(args):
         devices = {}
         for name in args.device_names:
             devices[name] = client.load_device(name=name)
+
+        from IPython import start_ipython  # noqa
         start_ipython(argv=['--quick'], user_ns=devices)
 
 

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -4,6 +4,7 @@ import builtins
 import logging
 import pytest
 import happi
+import IPython
 from happi.cli import happi_cli
 from unittest import mock
 from happi.errors import SearchError
@@ -312,7 +313,7 @@ def test_load(caplog, happi_cfg):
     devices = {}
     client = happi.client.Client.from_config(cfg=happi_cfg)
     devices['happi_name'] = client.load_device(name='happi_name')
-    with mock.patch.object(happi.cli, 'start_ipython') as m:
+    with mock.patch.object(IPython, 'start_ipython') as m:
         happi.cli.happi_cli(['--verbose', '--path',
                              happi_cfg, 'load', 'happi_name'])
         m.assert_called_once_with(argv=['--quick'], user_ns=devices)


### PR DESCRIPTION
## Description
* Adds `happi search --json` option to output JSON instead of a table.
* Moves IPython import to where it's needed, saving approximately half a second on any other `happi` CLI invocation
* Adds activate/deactivate scripts which can be used in conjunction with a fuzzy finder called `fzf`

Old video from issue #98: https://asciinema.org/a/358799
The video shows the underlying mechanism but not the (relatively) user-friendly option that this PR provides:
with this PR, you type `happi search **[TAB]` and it'll show that same filterable list of names.

## Motivation and Context
* Names are difficult to type and remember, even with globs

## How Has This Been Tested?
* Locally and manually