### PR TITLE
Questionnaire cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,27 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
+    -   id: no-commit-to-branch
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.8.3
     hooks:
     -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.6.4
+    hooks:
+    -   id: isort

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -243,7 +243,7 @@ class QuestionnaireHelper:
 
         for table_name, class_name in translations.items():
             devices = QuestionnaireHelper._translate_items(
-                run_details, table_name, class_name)
+                run_details, table_name)
 
             if not devices:
                 logger.info(

--- a/happi/client.py
+++ b/happi/client.py
@@ -12,8 +12,8 @@ import warnings
 from . import containers
 from .backends import BACKENDS, DEFAULT_BACKEND
 from .backends.core import _Backend
-from .item import HappiItem
 from .errors import DatabaseError, EntryError, SearchError
+from .item import HappiItem
 from .loader import from_container
 
 logger = logging.getLogger(__name__)
@@ -394,6 +394,7 @@ class Client(collections.abc.Mapping):
             except Exception as exc:
                 logger.warning('Entry for %s is malformed (%s). Skipping.',
                                info['name'], exc)
+                raise
         return results
 
     def search_range(self, key, start, end=None, **kwargs):

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -11,8 +11,9 @@ logger = logging.getLogger(__name__)
 
 # Conditional import of pymongo, mongomock
 try:
-    from happi.backends.mongo_db import MongoBackend
     from mongomock import MongoClient
+
+    from happi.backends.mongo_db import MongoBackend
     supported_backends = ['json', 'mongo']
 except ImportError as exc:
     logger.warning('Error importing mongomock : -> %s', exc)
@@ -24,6 +25,7 @@ requires_mongo = pytest.mark.skipif('mongo' not in supported_backends,
 # Conditional import of psdm_qs_cli
 try:
     from psdm_qs_cli import QuestionnaireClient
+
     from happi.backends.qs_db import QSBackend
     has_qs_cli = True
 except ImportError as exc:
@@ -134,9 +136,11 @@ def mockqsbackend():
     class MockQuestionnaireClient(QuestionnaireClient):
 
         def getProposalsListForRun(self, run):
-            return {'X534': {'Instrument': 'TST', 'proposal_id': 'X534'},
-                    'LR32': {'Instrument': 'TST', 'proposal_id': 'LR32'},
-                    'LU34': {'Instrument': 'MFX', 'proposal_id': 'LU34'}}
+            return {
+                'X534': {'Instrument': 'TST', 'proposal_id': 'X534'},
+                'LR32': {'Instrument': 'TST', 'proposal_id': 'LR32'},
+                'LU34': {'Instrument': 'MFX', 'proposal_id': 'LU34'},
+            }
 
         def getProposalDetailsForRun(self, run_no, proposal):
             return {
@@ -211,13 +215,15 @@ def mockqsbackend():
                 'pcdssetup-ai-1-device': 'Acromag IP231 16-bit',
                 'pcdssetup-ai-1-name': 'irLed',
                 'pcdssetup-ai-1-purpose': 'IR LED',
-                'pcdssetup-ai-1-pvbase': 'MFX:USR:ai1:0'}
+                'pcdssetup-ai-1-pvbase': 'MFX:USR:ai1:0',
+            }
 
         def getExpName2URAWIProposalIDs(self):
             return {
                 'tstx53416': 'X534',
                 'tstlr3216': 'LR32',
-                'mfxlu3417': 'LU34'}
+                'mfxlu3417': 'LU34',
+            }
 
     with patch('happi.backends.qs_db.QuestionnaireClient') as qs_cli:
         # Replace QuestionnaireClient with our test version
@@ -273,7 +279,7 @@ def three_valves(happi_client):
               'kwargs': {'hi': 'oh hello'},
               }
 
-    for dev in happi_client.all_devices:
+    for dev in happi_client.all_items:
         happi_client.backend.delete(dev['_id'])
 
     valves = dict(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add a questionnaire helper class to:
1. Break up loading routine into more maintainable functions
2. Allow for introspection of state

## Motivation and Context
Closes #175 

## How Has This Been Tested?
* Locally, but I'm hoping to add more tests
* Looking for an experiment that has valid entries for better testing, too

## Screenshots (if appropriate):

```python
In [1]: import happi
from happi.backends.qs_db import QSBackend

qs = QSBackend('xcsx41018', use_kerberos=True)

In [2]: qs.helper
Out[2]: <QuestionnaireHelper experiment=xcsx41018 run_number=run18 proposal=X410 beamline=XCS>
```