### PR TITLE
FIX: erroneously left in `raise` for testing purposes

### DIFF
--- a/happi/client.py
+++ b/happi/client.py
@@ -394,7 +394,6 @@ class Client(collections.abc.Mapping):
             except Exception as exc:
                 logger.warning('Entry for %s is malformed (%s). Skipping.',
                                info['name'], exc)
-                raise
         return results
 
     def search_range(self, key, start, end=None, **kwargs):


### PR DESCRIPTION
Mistakenly left in a `raise` I had used during testing to determine why questionnaire items weren't being loaded.

Only just noticed after comparing the releases (sorry, @ZLLentz )