### PR TITLE
Beckhoff axis to questionnaire

### DIFF
--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -260,6 +260,9 @@ class QuestionnaireHelper:
 
         if class_name is not None:
             entry['device_class'] = class_name
+        else:
+            if info.get('stageidentity') == 'Beckhoff':
+                entry['device_class'] = 'pcdsdevices.device_types.BeckhoffAxis'
 
         # Empty strings from the Questionnaire make for invalid entries:
         for key in {'prefix', 'name'}:

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -216,6 +216,11 @@ def mockqsbackend():
                 'pcdssetup-ai-1-name': 'irLed',
                 'pcdssetup-ai-1-purpose': 'IR LED',
                 'pcdssetup-ai-1-pvbase': 'MFX:USR:ai1:0',
+                'pcdssetup-motors-11-purpose': 'Von Hamos vertical',
+                'pcdssetup-motors-11-stageidentity': 'Beckhoff',
+                'pcdssetup-motors-11-location': 'XPP goniometer',
+                'pcdssetup-motors-11-pvbase': 'HXX:VON_HAMOS:MMS:01',
+                'pcdssetup-motors-11-name': 'vh_y_DONOTUSE',
             }
 
         def getExpName2URAWIProposalIDs(self):

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -220,7 +220,7 @@ def mockqsbackend():
                 'pcdssetup-motors-11-stageidentity': 'Beckhoff',
                 'pcdssetup-motors-11-location': 'XPP goniometer',
                 'pcdssetup-motors-11-pvbase': 'HXX:VON_HAMOS:MMS:01',
-                'pcdssetup-motors-11-name': 'vh_y_DONOTUSE',
+                'pcdssetup-motors-11-name': 'vh_y',
             }
 
         def getExpName2URAWIProposalIDs(self):

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -8,6 +8,7 @@ import simplejson
 from happi import Client
 from happi.backends.json_db import JSONBackend
 from happi.errors import DuplicateError, SearchError
+from happi.loader import load_devices
 
 from .conftest import (requires_mongo, requires_pcdsdevices,
                        requires_questionnaire)
@@ -187,5 +188,8 @@ def test_qsbackend_with_client(mockqsbackend):
 @requires_pcdsdevices
 def test_beckoff_axis_device_class(mockqsbackend):
     c = Client(database=mockqsbackend)
-    do_not_use = c.find_device(name='vh_y_donotuse')
-    do_not_use.device_class == 'pcdsdevices.device_types.BeckhoffAxis'
+    d = load_devices(*c.all_items).__dict__
+    do_not_use = d.get('vh_y_donotuse')
+    sam_x = d.get('sam_x')
+    assert do_not_use.__class__.__name__ == 'BeckhoffAxis'
+    assert sam_x.__class__.__name__ == 'IMS'

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -162,7 +162,7 @@ def test_json_initialize():
 
 @requires_questionnaire
 def test_qs_find(mockqsbackend):
-    assert len(list(mockqsbackend.find(dict(beamline='TST')))) == 13
+    assert len(list(mockqsbackend.find(dict(beamline='TST')))) == 14
     assert len(list(mockqsbackend.find(dict(name='sam_r')))) == 1
 
 
@@ -170,14 +170,22 @@ def test_qs_find(mockqsbackend):
 @requires_pcdsdevices
 def test_qsbackend_with_client(mockqsbackend):
     c = Client(database=mockqsbackend)
-    assert len(c.all_items) == 13
+    assert len(c.all_items) == 14
     assert all(
         d.__class__.__name__ in {'Trigger', 'Motor', 'Acromag'}
         for d in c.all_items
     )
     device_types = [device.__class__.__name__ for device in c.all_items]
-    assert device_types.count('Motor') == 6
+    assert device_types.count('Motor') == 7
     assert device_types.count('Trigger') == 2
 
     # Acromag: six entries, but one erroneously has the same name
     assert device_types.count('Acromag') == 5
+
+
+@requires_questionnaire
+@requires_pcdsdevices
+def test_beckoff_axis_device_class(mockqsbackend):
+    c = Client(database=mockqsbackend)
+    do_not_use = c.find_device(name='vh_y_donotuse')
+    do_not_use.device_class == 'pcdsdevices.device_types.BeckhoffAxis'

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -189,7 +189,7 @@ def test_qsbackend_with_client(mockqsbackend):
 def test_beckoff_axis_device_class(mockqsbackend):
     c = Client(database=mockqsbackend)
     d = load_devices(*c.all_items).__dict__
-    do_not_use = d.get('vh_y_donotuse')
+    do_not_use = d.get('vh_y')
     sam_x = d.get('sam_x')
     assert do_not_use.__class__.__name__ == 'BeckhoffAxis'
     assert sam_x.__class__.__name__ == 'IMS'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added some support for BeckhoffAxis type motor when creating the entry from questionnaire.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to close https://github.com/pcdshub/Bug-Reports-and-Requests/issues/53
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not sure if this is a good enough test:
```
In [1]: import hutch_python.qs_load as qs_load

In [2]: experiment = 'xpplv6818'

In [3]: obj = qs_load.get_qs_objs(experiment)

In [4]: v = obj.get('vh_y_donotuse')

In [5]: v.check_value
Out[5]: <bound method EpicsMotorInterface.check_value of BeckhoffAxis(HXX:VON_HAMOS:MMS:01, name=vh_y_donotuse)>

In [6]: vx = obj.get('vh_x')

In [7]: vx.check_value
Out[7]: <bound method PCDSMotorBase.check_value of IMS(XPP:USR:MMS:17, name=vh_x)>
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
