### PR TITLE
[WIP] add YAQItem class

### DIFF
--- a/happi/item.py
+++ b/happi/item.py
@@ -363,3 +363,11 @@ class OphydItem(HappiItem):
     args.default = ['{{prefix}}']
     kwargs = copy.copy(HappiItem.kwargs)
     kwargs.default = {'name': '{{name}}'}
+
+
+class YAQItem(HappiItem):
+    port = EntryInfo("TCP port.", enforce=int, optional=False)
+    host = EntryInfo("Host.", optional=True, default="localhost")
+    kwargs = copy.copy(HappiItem.kwargs)
+    kwargs.default = {'port': '{{port}}', 'host': '{{host}}'}
+    device_class = EntryInfo(default="yaqc.Client")

--- a/happi/item.py
+++ b/happi/item.py
@@ -369,5 +369,7 @@ class YAQItem(HappiItem):
     port = EntryInfo("TCP port.", enforce=int, optional=False)
     host = EntryInfo("Host.", optional=True, default="localhost")
     kwargs = copy.copy(HappiItem.kwargs)
-    kwargs.default = {'port': '{{port}}', 'host': '{{host}}'}
-    device_class = EntryInfo(default="yaqc.Client")
+    kwargs.default = {'port': '{{port}}',
+                      'host': '{{host}}',
+                      'name': '{{name}}'}
+    device_class = EntryInfo(default="yaqc_bluesky.Device")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Adds support for [yaq](https://yaq.fyi) to happi.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Would like to use happi to manage yaq devices alongside other bluesky interface sources :heart:.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally. Would love to add tests but would like some direction from maintainers. We have [yaqd-fakes](https://gitlab.com/yaq/yaq-python/-/tree/master/yaqd-fakes) so it'll be easy to stand up some daemons for testing purposes. Marked as WIP because I'd like to see tests added before merge.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Willing to document, would like some direction from maintainers.

<!--
## Screenshots (if appropriate):
-->
