### PR TITLE
FIX: expand home directory (~) in JSON backend database path

### DIFF
--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -47,7 +47,7 @@ class JSONBackend(_Backend):
     """
 
     def __init__(self, path, initialize=False):
-        self.path = path
+        self.path = os.path.expanduser(path)
         # Create a new JSON file if requested
         if initialize:
             self.initialize()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Pass jsondb path through `os.path.expanduser` .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I expect the following cfg file to work:

```ini
[DEFAULT]
path = ~/.local/share/happi/db.json
```

Currently it does not, happi requires FULL path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Not documented.

<!--
## Screenshots (if appropriate):
-->
