### PR TITLE
happi update <json>

### DIFF
--- a/happi/cli.py
+++ b/happi/cli.py
@@ -58,6 +58,11 @@ def get_parser():
                                         'given device loaded.')
     parser_load.add_argument('device_names', nargs='+',
                              help='The names of one or more devices to load')
+    parser_update = subparsers.add_parser("update",
+                                          help="Update happi db "
+                                          "with JSON payload.")
+    parser_update.add_argument("json", help="JSON payload.",
+                               default="-", nargs="*")
     return parser
 
 
@@ -252,6 +257,19 @@ def happi_cli(args):
 
         from IPython import start_ipython  # noqa
         start_ipython(argv=['--quick'], user_ns=devices)
+    elif args.cmd == "update":
+        # parse input
+        input_ = " ".join(args.json).strip()
+        if input_ == "-":
+            items_input = json.load(sys.stdin)
+        else:
+            items_input = json.loads(input_)
+        # insert
+        registry = happi.containers.registry
+        for item in items_input:
+            item = client.create_device(device_cls=item["type"], **item)
+            exists = item["_id"] in [c["_id"] for c in client.all_items]
+            client._store(item, insert=not exists)
 
 
 def main():

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -265,7 +265,6 @@ def happi_cli(args):
         else:
             items_input = json.loads(input_)
         # insert
-        registry = happi.containers.registry
         for item in items_input:
             item = client.create_device(device_cls=item["type"], **item)
             exists = item["_id"] in [c["_id"] for c in client.all_items]

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -321,3 +321,35 @@ def test_load(caplog, happi_cfg):
         m.assert_called_once_with(argv=['--quick'], user_ns=devices)
     with caplog.at_level(logging.INFO):
         assert "Creating shell with devices" in caplog.text
+
+
+def test_update(happi_cfg):
+    new = """[ {
+        "_id": "TST_BASE_PIM2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "TST",
+        "creation": "Wed Jan 30 09:46:00 2019",
+        "device_class": "types.SimpleNamespace",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Fri Apr 13 14:40:08 2018",
+        "macros": null,
+        "name": "tst_base_pim2",
+        "parent": null,
+        "prefix": "TST:BASE:PIM2",
+        "screen": null,
+        "stand": "BAS",
+        "system": "diagnostic",
+        "type": "OphydItem",
+        "z": 6.0,
+        "from_update": true
+    } ] """
+    happi.cli.happi_cli(["--verbose", "--path", happi_cfg, "update", new])
+    #
+    client = happi.client.Client.from_config(cfg=happi_cfg)
+    item = client.find_device(name="tst_base_pim2")
+    assert item["from_update"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Add new CLI sytntax: `happi update <json>`. User supplies a JSON payload defining Happi items. Items from payload are verified then splatted into the database. In the case of an `_id` conflict, the NEW item is preferred and the old item is overwritten. Name is inspired by Python's `dict.update` method.

Closes #190.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This syntax allows for bulk management of the Happi database through easy integration with other command line tools. I am simultaneously updating yaqd to introduce Happi-formatted output, see [GitLab MR](https://gitlab.com/yaq/yaqd-control/-/merge_requests/42).

It is my hope that this interface will allow for other device-discovery tools to easily add Happi support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally. All of the following work on my machine.

```bash
$ yaqd list -f happi | happi update
$ happi search '*' --json | happi update
$ happi update "$(yaqd list -f happi)"
$ happi update "$(happi search '*' --json)"
```

I want to write tests for Happi CI! I'd like some guidance from maintainers if possible.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Willing to document, would like guidance from maintainers :sweat_smile: 

In addition to documenting `happi update` itself, I'd like to encourage documentation of the "standardized" HappiItem JSON representation. This will allow other developers to confidently create tooling for this interface.