### PR TITLE
ENH: allow short and long names

### DIFF
--- a/docs/source/containers.rst
+++ b/docs/source/containers.rst
@@ -96,14 +96,15 @@ real value is given it will be checked against the specified ``enforce``
 keyword, raising ``ValueError`` if invalid. Here is a table for how the
 :class:`.EntryInfo` check the type
 
-=======   ===========================
-Enforce   Method of enforcement
-=======   ===========================
-None      Any value will work
-type      type(value)
-list      list.index(value)
-regex     regex.match(value) != None
-=======   ===========================
+========   ===========================
+Enforce    Method of enforcement
+========   ===========================
+None       Any value will work
+type       type(value)
+list       list.index(value)
+regex      regex.match(value) != None
+function   function(value)
+========   ===========================
 
 Fields that are important to the item can be marked as mandatory with
 ``optional=False`` and should have no default value.

--- a/happi/item.py
+++ b/happi/item.py
@@ -32,10 +32,14 @@ class EntryInfo:
     optional : bool, optional
         By default all EntryInfo is optional, but in certain cases you may want
         to demand a particular piece of information upon initialization.
-    enforce : type or list or compiled regex, optional
+    enforce : type, list, compiled regex, or function, optional
         Specify that all entered information is entered in a specific format.
         This can either by a Python type i.e. int, float e.t.c., a list of
-        acceptable values, or a compiled regex pattern i.e ``re.compile(...)``
+        acceptable values, a compiled regex pattern i.e ``re.compile(...)``,
+        or custom handling by passing a function that takes in one argument,
+        the value. This function must do one of: return the value back as-is,
+        return the value back converted to a corrected form, or raise a
+        ValueError.
     default : optional
         A default value for the trait to have if the user does not specify.
         Keep in mind that this should be the same type as ``enforce`` if you
@@ -108,8 +112,9 @@ class EntryInfo:
                 raise ValueError(f'{value} as a string is not interpretable '
                                  'as a boolean.')
 
-        elif isinstance(self.enforce, type):
-            # Try and convert to type, otherwise raise ValueError
+        elif callable(self.enforce):
+            # Try and convert to type or custom handling
+            # Otherwise raise ValueError for types, custom handling otherwise
             return self.enforce(value)
 
         elif isinstance(self.enforce, (list, tuple, set)):

--- a/happi/item.py
+++ b/happi/item.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from prettytable import PrettyTable
 
 from .errors import ContainerError
+from .utils import is_valid_identifier_not_keyword
 
 logger = logging.getLogger(__name__)
 
@@ -266,7 +267,7 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
 
     name = EntryInfo("Shorthand Python-valid name for the Python instance",
                      optional=False,
-                     enforce=re.compile(r'[_A-Za-z][_a-zA-Z0-9]*$'))
+                     enforce=is_valid_identifier_not_keyword)
     device_class = EntryInfo("Python class that represents the instance",
                              enforce=str)
     args = EntryInfo("Arguments to pass to device_class",

--- a/happi/item.py
+++ b/happi/item.py
@@ -248,7 +248,7 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
 
     name = EntryInfo("Shorthand Python-valid name for the Python instance",
                      optional=False,
-                     enforce=re.compile(r'[a-z][a-z\_0-9]{2,78}$'))
+                     enforce=re.compile(r'[_A-Za-z][_a-zA-Z0-9]*$'))
     device_class = EntryInfo("Python class that represents the instance",
                              enforce=str)
     args = EntryInfo("Arguments to pass to device_class",

--- a/happi/item.py
+++ b/happi/item.py
@@ -1,7 +1,6 @@
 import collections
 import copy
 import logging
-import re
 import sys
 from collections import OrderedDict
 

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -1,6 +1,7 @@
 """
 Basic module utilities
 """
+import keyword
 import logging
 
 logger = logging.getLogger(__name__)
@@ -54,3 +55,13 @@ def is_a_range(str_value):
             return False
     else:
         return False
+
+
+def is_valid_identifier_not_keyword(str_value):
+    try:
+        if str.isidentifier(str_value) and not keyword.iskeyword(str_value):
+            return str_value
+    except Exception:
+        pass
+    raise ValueError(f'{str_value} is either not a valid Python identifier, '
+                     'or is a reserved keyword.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Remove the requirement for names to be between 3 and 80 characters
- Keep requirement for names to be valid Python identifiers
- Add previously implicit requirement for names to not conflict with reserved keywords
- Add feature to use arbitrary functions as enforce parameters

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a site-specific assumption that should not be baked in to the base class
closes #206 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
~Online regex tester site to quickly vet python identifier~
The above is no longer valid, since we are no longer using regex here.
But I think this is fine since the existing tests still pass and we're using core python built-ins to validate the names, rather than custom regex.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added some to the docs folder
Will be in the release notes
<!--
## Screenshots (if appropriate):
-->
