### PR TITLE
MNT: fix confusing behavior with boolean enforcement

### DIFF
--- a/happi/item.py
+++ b/happi/item.py
@@ -98,8 +98,8 @@ class EntryInfo:
         elif self.enforce is bool and isinstance(value, str):
             # Special case for booleans, since the value may come in as a
             # string, and bool('False') evaluates to True
-            true_values = ['true', 'yes']
-            false_values = ['false', 'no']
+            true_values = ['true', 't', 'yes', 'y']
+            false_values = ['false', 'f', 'no', 'n']
             if value.lower() in true_values:
                 return True
             elif value.lower() in false_values:

--- a/happi/item.py
+++ b/happi/item.py
@@ -95,6 +95,19 @@ class EntryInfo:
         if not self.enforce or value is None:
             return value
 
+        elif self.enforce is bool and isinstance(value, str):
+            # Special case for booleans, since the value may come in as a
+            # string, and bool('False') evaluates to True
+            true_values = ['true', 'yes']
+            false_values = ['false', 'no']
+            if value.lower() in true_values:
+                return True
+            elif value.lower() in false_values:
+                return False
+            else:
+                raise ValueError(f'{value} as a string is not interpretable '
+                                 'as a boolean.')
+
         elif isinstance(self.enforce, type):
             # Try and convert to type, otherwise raise ValueError
             return self.enforce(value)

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -56,7 +56,7 @@ def test_type_enforce_ok(type_spec, value, expected):
 
 
 @pytest.mark.parametrize('type_spec, value',
-                         [(int, 'cats'), (int, 0.3),
+                         [(int, 'cats'),
                           (bool, '24'), (bool, 'catastrophe')])
 def test_type_enforce_exceptions(type_spec, value):
     entry = EntryInfo(enforce=type_spec)

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -52,7 +52,7 @@ def test_regex_enforce():
                           (bool, 'true', True), (bool, 'NO', False)])
 def test_type_enforce_ok(type_spec, value, expected):
     entry = EntryInfo(enforce=type_spec)
-    assert entry.enforce(value) == expected
+    assert entry.enforce_value(value) == expected
 
 
 @pytest.mark.parametrize('type_spec, value',
@@ -61,7 +61,7 @@ def test_type_enforce_ok(type_spec, value, expected):
 def test_type_enforce_exceptions(type_spec, value):
     entry = EntryInfo(enforce=type_spec)
     with pytest.raises(ValueError):
-        entry.enforce(value)
+        entry.enforce_value(value)
 
 
 def test_set(device):

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -45,6 +45,25 @@ def test_regex_enforce():
         d.re_attr = 'ABC'
 
 
+@pytest.mark.parametrize('type_spec, value, expected',
+                         [(int, 0, 0), (int, 1, 1), (int, 2.0, 2),
+                          (str, 'hat', 'hat'), (str, 5, '5'),
+                          (bool, True, True), (bool, 0, False),
+                          (bool, 'true', True), (bool, 'NO', False)])
+def test_type_enforce_ok(type_spec, value, expected):
+    entry = EntryInfo(enforce=type_spec)
+    assert entry.enforce(value) == expected
+
+
+@pytest.mark.parametrize('type_spec, value',
+                         [(int, 'cats'), (int, 0.3),
+                          (bool, '24'), (bool, 'catastrophe')])
+def test_type_enforce_exceptions(type_spec, value):
+    entry = EntryInfo(enforce=type_spec)
+    with pytest.raises(ValueError):
+        entry.enforce(value)
+
+
 def test_set(device):
     device.name = 'new_name'
     assert device.name == 'new_name'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a special case for boolean entry enforcement where we interpret the input string instead of just casting it into a boolean.
Accepts strings like "true" and "false" as stand-ins for `True` and `False` in situations where the input must be given as a string, such as in the cli.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`happi edit` and `happi add` do not set boolean values as one would expect
closes #187

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Will include in release notes, I'm going to count this as a bugfix.

<!--
## Screenshots (if appropriate):
-->
