### PR TITLE
ENH: add command to display container registry

### DIFF
--- a/happi/cli.py
+++ b/happi/cli.py
@@ -274,10 +274,12 @@ def happi_cli(args):
             client._store(item, insert=not exists)
     elif args.cmd == "container-registry":
         pt = prettytable.PrettyTable()
-        pt.field_names = ["Type", "Device Class"]
+        pt.field_names = ["Type", "Item Class", "Device Class"]
         pt.align = "l"
-        for item in happi.containers.registry._registry.items():
-            pt.add_row(item)
+        for type_, class_, in happi.containers.registry._registry.items():
+            pt.add_row([type_,
+                        f'{class_.__module__}.{class_.__name__}',
+                        class_.device_class.default])
         print(pt)
 
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -9,6 +9,7 @@ import os
 import sys
 
 import coloredlogs
+import prettytable
 
 import happi
 
@@ -63,6 +64,8 @@ def get_parser():
                                           "with JSON payload.")
     parser_update.add_argument("json", help="JSON payload.",
                                default="-", nargs="*")
+    parser_update = subparsers.add_parser("container-registry",
+                                          help="Print container registry.")
     return parser
 
 
@@ -269,6 +272,13 @@ def happi_cli(args):
             item = client.create_device(device_cls=item["type"], **item)
             exists = item["_id"] in [c["_id"] for c in client.all_items]
             client._store(item, insert=not exists)
+    elif args.cmd == "container-registry":
+        pt = prettytable.PrettyTable()
+        pt.field_names = ["Type", "Device Class"]
+        pt.align = "l"
+        for item in happi.containers.registry._registry.items():
+            pt.add_row(item)
+        print(pt)
 
 
 def main():

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -274,7 +274,7 @@ def happi_cli(args):
             client._store(item, insert=not exists)
     elif args.cmd == "container-registry":
         pt = prettytable.PrettyTable()
-        pt.field_names = ["Type", "Item Class", "Device Class"]
+        pt.field_names = ["Container Name", "Container Class", "Object Class"]
         pt.align = "l"
         for type_, class_, in happi.containers.registry._registry.items():
             pt.add_row([type_,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Adding new command to CLI.

```
$ happi container-registry
+------------------------------------+------------------------------------+-------------------------------+
| Container Name                     | Container Class                    | Object Class                  |
+------------------------------------+------------------------------------+-------------------------------+
| Device                             | happi.device.Device                | None                          |
| OphydItem                          | happi.item.OphydItem               | None                          |
| HappiItem                          | happi.item.HappiItem               | None                          |
| bluesky_autonomic._happi.DelayItem | bluesky_autonomic._happi.DelayItem | bluesky_autonomic.DelayDevice |
| bluesky_autonomic._happi.OPAItem   | bluesky_autonomic._happi.OPAItem   | bluesky_autonomic.OPADevice   |
| yaq._happi.YAQItem                 | yaqc_bluesky._happi.YAQItem        | yaqc_bluesky.Device           |
+------------------------------------+------------------------------------+-------------------------------+
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For debugging purposes it's become useful for me to inspect what container types happi has successfully loaded through the entry-points system. This can be done from within Python, but now in the fast-paced world of docker and many device-providing packages it's even better to be able to see this information from the shell. Just scratching my own itch here!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Works on my machine :laughing: 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

CLI is automatically documented.

<!--
## Screenshots (if appropriate):
-->
