### PR TITLE
MNT: fix logging format for client backend kwargs

### DIFF
--- a/happi/client.py
+++ b/happi/client.py
@@ -677,7 +677,11 @@ class Client(collections.abc.Mapping):
         else:
             backend = DEFAULT_BACKEND
 
-        logger.debug("Using Happi backend %r with kwargs", backend, db_kwargs)
+        logger.debug(
+            "Using Happi backend %r with kwargs %s",
+            backend, db_kwargs
+        )
+
         # Create our database with provided kwargs
         try:
             database = backend(**db_kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Log message format string was not including kwargs; this PR addresses that.

## Motivation and Context
Quick fix as I noticed a long happi traceback in my log messages

## How Has This Been Tested?
Used `happi` and saw appropriate log message instead of traceback.