### PR TITLE
ENH: cli search flag to output names

### DIFF
--- a/happi/cli.py
+++ b/happi/cli.py
@@ -38,6 +38,8 @@ def get_parser():
                                           'database.')
     parser_search.add_argument('--json', action='store_true',
                                help='Show results in JSON format.')
+    parser_search.add_argument('--names', action='store_true',
+                               help='Return results as whitespace-separated names.')
     parser_search.add_argument('search_criteria', nargs='+',
                                help='Search criteria of the form: '
                                'field=value. If "field=" is omitted, it will '
@@ -168,6 +170,9 @@ def happi_cli(args):
         if args.json:
             json.dump([dict(res.item) for res in final_results], indent=2,
                       fp=sys.stdout)
+        elif args.names:
+            out = " ".join([res.item.name for res in final_results])
+            print(out)
         else:
             for res in final_results:
                 res.item.show_info()
@@ -255,7 +260,9 @@ def happi_cli(args):
         logger.debug('Starting load block')
         logger.info(f'Creating shell with devices {args.device_names}')
         devices = {}
-        for name in args.device_names:
+        names = " ".join(args.device_names)
+        names = names.split()
+        for name in names:
             devices[name] = client.load_device(name=name)
 
         from IPython import start_ipython  # noqa

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -39,7 +39,8 @@ def get_parser():
     parser_search.add_argument('--json', action='store_true',
                                help='Show results in JSON format.')
     parser_search.add_argument('--names', action='store_true',
-                               help='Return results as whitespace-separated names.')
+                               help='Return results as '
+                               'whitespace-separated names.')
     parser_search.add_argument('search_criteria', nargs='+',
                                help='Search criteria of the form: '
                                'field=value. If "field=" is omitted, it will '


### PR DESCRIPTION
## Description

Enable new flag to `happi search`, `--names`.

```bash
$ happi search "*"
(pretty table)
& happi search "*" --names
d1 d2 mysensor
```

If both `--json` and `--names` are provided the output is json.

Feel free to reject or ask for major changes.

## Motivation and Context

Motivated by #231, I can now do this:

```bash
$ happi load "$(happi search "*" --names)"
[2021-12-22 12:04:39] - INFO -  Creating shell with devices ['d1 d2 mysensor']
Python 3.9.9 | packaged by conda-forge | (main, Dec 20 2021, 02:41:03) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: d1
Out[1]: <yaqc_bluesky._device.YAQDevice at 0x7f41ed902f10>
```

I had to massage `load` a little bit to do this, but not in a way that changes existing behavior.

I don't think this closes that PR, as I still would prefer direct syntax if possible.

## How Has This Been Tested?

Works on my machine :wink: 