### PR TITLE
ENH: optional per-device load times

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.1.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -18,11 +18,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
     -   id: isort

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -35,7 +35,7 @@ def fill_template(
     template : str
         Jinja2 template source.
 
-    device : HappItem
+    device : HappiItem
         Any happi item container.
 
     enforce_type : bool, optional

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -145,8 +145,9 @@ def from_container(device, attach_md=True, use_cache=True, threaded=False):
 
     # Find the class and module of the container.
     if not device.device_class:
-        raise ValueError("Device %s does not have an associated Python class",
-                         device.name)
+        raise ValueError(
+            f"Device {device.name} does not have an associated Python class"
+        )
 
     cls = import_class(device.device_class)
 

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -230,6 +230,8 @@ def load_devices(
     use_cache: bool = True,
     threaded: bool = False,
     post_load: Optional[PostLoad] = None,
+    include_load_time: bool = False,
+    load_time_threshold: float = 0.5,
     **kwargs
 ):
     """
@@ -256,6 +258,11 @@ def load_devices(
         Function of one argument to run on each device after instantiation.
         This is your opportunity to check for good device health during the
         threaded load.
+    include_load_time : bool, optional
+        Include load time in each message.
+    load_time_threshold : float, optional
+        Load time above this value, in seconds, will be shown if
+        ``include_load_time`` is set.
     kwargs
         Additional keyword arguments passed to :func:`.from_container`.
     """
@@ -275,14 +282,30 @@ def load_devices(
         if main_event_loop is None:
             main_event_loop = asyncio.get_event_loop()
         pool = ThreadPool(len(devices))
-        opt_load = partial(load_device, pprint=pprint, use_cache=use_cache,
-                           threaded=True, post_load=post_load, **kwargs)
+        opt_load = partial(
+            load_device,
+            pprint=pprint,
+            use_cache=use_cache,
+            threaded=True,
+            post_load=post_load,
+            include_load_time=include_load_time,
+            load_time_threshold=load_time_threshold,
+            **kwargs
+        )
         loaded_list = pool.map(opt_load, devices)
     else:
         loaded_list = []
         for device in devices:
-            loaded = load_device(device, pprint=pprint, use_cache=use_cache,
-                                 threaded=False, post_load=post_load, **kwargs)
+            loaded = load_device(
+                device,
+                pprint=pprint,
+                use_cache=use_cache,
+                threaded=False,
+                post_load=post_load,
+                include_load_time=include_load_time,
+                load_time_threshold=load_time_threshold,
+                **kwargs
+            )
             loaded_list.append(loaded)
     for dev, name in zip(loaded_list, name_list):
         attr = create_alias(name)

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -373,25 +373,26 @@ def load_device(
             return f" ({elapsed_time:.1f} s)"
         return ""
 
+    def print_load_message(message: str, elapsed: str) -> None:
+        if not pprint:
+            return
+
+        if threaded:
+            print(f"{load_message} {message}{elapsed}")
+        else:
+            print(f"{message}{elapsed}")
+
     try:
         loaded = from_container(device, **kwargs)
         if post_load is not None:
             post_load(loaded)
     except Exception as exc:
         elapsed = get_load_time()
-        if pprint:
-            if threaded:
-                print(f"{load_message} {failed}{elapsed}")
-            else:
-                print(f"{failed}{elapsed}")
+        print_load_message(failed, elapsed)
         logger.exception("Error loading %s%s", device.name, elapsed)
-        loaded = exc
-    else:
-        elapsed = get_load_time()
-        logger.info("%s %s%s", load_message, success, elapsed)
-        if pprint:
-            if threaded:
-                print(f"{load_message} {success}{elapsed}")
-            else:
-                print("{success}{elapsed}")
+        return exc
+
+    elapsed = get_load_time()
+    logger.info("%s %s%s", load_message, success, elapsed)
+    print_load_message(success, elapsed)
     return loaded

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -70,9 +70,28 @@ def test_add_md():
     assert obj.md.name == 'test'
 
 
-@pytest.mark.parametrize('threaded', [False, True])
-@pytest.mark.parametrize('post_load', [None, lambda x: None])
-def test_load_devices(threaded, post_load):
+@pytest.mark.parametrize(
+    "threaded",
+    [
+        pytest.param(False, id="unthreaded"),
+        pytest.param(True, id="threaded")
+    ],
+)
+@pytest.mark.parametrize(
+    "post_load",
+    [
+        pytest.param(None, id="no_post_load"),
+        pytest.param(lambda x: None, id="post_load"),
+    ],
+)
+@pytest.mark.parametrize(
+    "include_load_time",
+    [
+        pytest.param(False, id="no_load_times"),
+        pytest.param(True, id="load_times")
+    ],
+)
+def test_load_devices(threaded: bool, post_load, include_load_time: bool):
     # Create a bunch of devices to load
     devs = [TimeDevice(name='test_1', prefix='Tst1:This', beamline='TST',
                        device_class='datetime.timedelta', args=list(), days=10,
@@ -86,8 +105,14 @@ def test_load_devices(threaded, post_load):
             Device(name='bad', prefix='Not:Here', beamline='BAD',
                    device_class='non.existant')]
     # Load our devices
-    space = load_devices(*devs, pprint=True, use_cache=False,
-                         threaded=threaded, post_load=post_load)
+    space = load_devices(
+        *devs,
+        pprint=True,
+        use_cache=False,
+        threaded=threaded,
+        post_load=post_load,
+        include_load_time=include_load_time,
+    )
     # Check all our devices are there
     assert all([create_alias(dev.name) in space.__dict__ for dev in devs])
     # Devices were loading properly or exceptions were stored


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Only affects those using `load_device` or `load_devices`, which are CLI-facing wrappers around `load_container` (used by `client[device].get()`
   * Are there any users outside of SLAC for this?
* Cleans and annotates `happi.loader`
* Some warning messages were made more descriptive
* Consolidated message printing logic
* Bonus: updates old pre-commit settings

## Motivation and Context
* Some devices take a long time to load, it would be nice to know which without digging too much

## How Has This Been Tested?
* hutch-python loading and test suite

## Where Has This Been Documented?
This PR text

## Screenshots (if appropriate):
<img width="755" alt="image" src="https://user-images.githubusercontent.com/5139267/157307554-dafeb796-7068-4f03-97c5-6baa7d88e550.png">
