### PR TITLE
BLD: move psdm_qs_cli, pymongo to run-constrained reqs

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,9 +22,10 @@ requirements:
       - entrypoints
       - jinja2
       - prettytable
+      - simplejson
+    run-constrained:
       - psdm_qs_cli
       - pymongo
-      - simplejson
 
 test:
     imports:


### PR DESCRIPTION
## Description
Moves psdm_qs_cli, pymongo to the run-constrained section of the conda recipe 

## Motivation and Context
#202 

## How Has This Been Tested?
I'm actually not sure how to test this

## Where Has This Been Documented?
This PR
