### PR TITLE
ENH: add enforce_doc kwarg to EntryInfo

### DIFF
--- a/docs/source/containers.rst
+++ b/docs/source/containers.rst
@@ -75,7 +75,8 @@ class attributes as EntryInfo objects:
         count         = EntryInfo('Count of Item', enforce=int, default=0)
         choices       = EntryInfo('Choice Info', enforce=['a','b','c'])
         no_whitespace = EntryInfo('Enforce no whitespace',
-                                   enforce = re.compile(r'[\S]*$'))
+                                   enforce = re.compile(r'[\S]*$'),
+                                   enforce_doc = 'This item cannot have whitespace')
 
 By default, :class:`.EntryInfo` will create an optional init keyword argument with a
 default of ``None`` with the same name as the class attribute. A quick way
@@ -105,6 +106,11 @@ list       list.index(value)
 regex      regex.match(value) != None
 function   function(value)
 ========   ===========================
+
+If your enforce condition is complicated or obfuscated, you can add a
+docstring using the ``enforce_doc`` keyword that explains the rule.
+(This may be helpful for regex matches which are difficult for humans
+to read)
 
 Fields that are important to the item can be marked as mandatory with
 ``optional=False`` and should have no default value.

--- a/happi/item.py
+++ b/happi/item.py
@@ -121,7 +121,10 @@ class EntryInfo:
         elif callable(self.enforce):
             # Try and convert to type or custom handling
             # Otherwise raise ValueError for types, custom handling otherwise
-            return self.enforce(value)
+            try:
+                return self.enforce(value)
+            except ValueError as e:
+                raise ValueError(self.enforce_doc) from e
 
         elif isinstance(self.enforce, (list, tuple, set)):
             # Check that value is in list, otherwise raise ValueError

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -21,7 +21,8 @@ def test_init(device, device_info):
 def test_list_enforce():
     # Generic device with a list enforce
     class MyDevice(Device):
-        list_attr = EntryInfo(enforce=['a', 'b', 'c'])
+        list_attr = EntryInfo(enforce=['a', 'b', 'c'],
+                              enforce_doc='list only')
 
     # Make sure we can set without error
     d = MyDevice()
@@ -29,20 +30,25 @@ def test_list_enforce():
     assert d.list_attr == 'b'
     # Mase sure we can not set outside the list
     d = MyDevice()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         d.list_attr = 'd'
+
+    assert 'list only' in str(excinfo)
 
 
 def test_regex_enforce():
     class MyDevice(Device):
-        re_attr = EntryInfo(enforce=re.compile(r'[A-Z]{2}$'))
+        re_attr = EntryInfo(enforce=re.compile(r'[A-Z]{2}$'),
+                            enforce_doc='only 2 chars')
 
     d = MyDevice()
     d.re_attr = 'AB'
 
     d = MyDevice()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         d.re_attr = 'ABC'
+
+    assert 'only 2 chars' in str(excinfo)
 
 
 @pytest.mark.parametrize('type_spec, value, expected',
@@ -59,9 +65,11 @@ def test_type_enforce_ok(type_spec, value, expected):
                          [(int, 'cats'),
                           (bool, '24'), (bool, 'catastrophe')])
 def test_type_enforce_exceptions(type_spec, value):
-    entry = EntryInfo(enforce=type_spec)
-    with pytest.raises(ValueError):
+    entry = EntryInfo(enforce=type_spec, enforce_doc='bad type')
+    with pytest.raises(ValueError) as excinfo:
         entry.enforce_value(value)
+
+    assert 'bad type' in str(excinfo)
 
 
 def test_set(device):


### PR DESCRIPTION
## Description
- Adds `enforce_doc` kwarg to EntryInfo for more informative exceptions on enforcement failure
- updates some docs to make this more visible.
- added some assertions in tests to make sure this is visible

## Motivation and Context
closes #217 

## How Has This Been Tested?
Interactively, tests have been updated

## Where Has This Been Documented?
Documentation has been updated