### PR TITLE
TST: use tempfile for mockjsonclient fixture

### DIFF
--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -93,12 +94,14 @@ def valve(valve_info):
 @pytest.fixture(scope='function')
 def mockjsonclient(device_info):
     # Write underlying database
-    with open('testing.json', 'w+') as handle:
+    with tempfile.NamedTemporaryFile(mode='w') as handle:
         simplejson.dump({device_info['name']: device_info},
                         handle)
-    # Return handle name
-    db = JSONBackend('testing.json')
-    return Client(database=db)
+        handle.flush()  # flush buffer to write file
+        # Return handle name
+        db = JSONBackend(handle.name)
+        yield Client(database=db)
+        # tempfile will be deleted once context manager is resolved
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -1,6 +1,7 @@
 import fcntl
 import os
 import os.path
+import tempfile
 
 import pytest
 import simplejson
@@ -22,14 +23,12 @@ def mockmongo(mockmongoclient):
 @pytest.fixture(scope='function')
 def mockjson(device_info, valve_info):
     # Write underlying database
-    with open('testing.json', 'w+') as handle:
+    with tempfile.NamedTemporaryFile(mode='w') as handle:
         simplejson.dump({device_info['_id']: device_info},
                         handle)
-    # Return handle name
-    yield JSONBackend('testing.json')
-
-    # Delete file
-    os.remove('testing.json')
+        handle.flush()
+        # Return handle name
+        yield JSONBackend(handle.name)
 
 
 @requires_mongo


### PR DESCRIPTION
## Description
- uses tempfile.NamedTemporaryFile instead of writing a .json file and cleaning it up (in conftest.py and test_backends.py)

## Motivation and Context
closes #216 

There are still portions where json is created, but the writing of those files seems to be the target of the test, so I've left those alone

## How Has This Been Tested?
Tests run and no json is left behind.  

## Where Has This Been Documented?
This PR
