### PR TITLE
WIP/ENH: add transfer cli tool and associated tools

### DIFF
--- a/happi/item.py
+++ b/happi/item.py
@@ -124,13 +124,16 @@ class EntryInfo:
             try:
                 return self.enforce(value)
             except ValueError as e:
-                raise ValueError(self.enforce_doc) from e
+                if self.enforce_doc:
+                    raise ValueError(self.enforce_doc) from e
+                else:
+                    raise e
 
         elif isinstance(self.enforce, (list, tuple, set)):
             # Check that value is in list, otherwise raise ValueError
             if value not in self.enforce:
                 raise ValueError('{} was not found in the enforce list {}. '
-                                 ''.format(self.key, self.enforce) +
+                                 ''.format(value, self.enforce) +
                                  f'{self.enforce_doc}')
             return value
 

--- a/happi/prompt.py
+++ b/happi/prompt.py
@@ -1,0 +1,84 @@
+import click
+import prettytable
+
+from .loader import change_container
+
+
+def transfer_container(item, target):
+    """
+    Interactively step through transferring an item into a new container
+    Works by catching exceptions and prompting for updates
+
+    Control flow:
+    - print keys of both (show_info)
+        - prompt for how to join
+        - prompt entry for any missing key
+            - check enforce, prompt to fix
+        - prompt for how to handle extra keys
+        -
+    - attempt to convert
+        - while errors still exist (what errors will be here?)
+            - prompt to fix enforce errors?
+            - prompt to fix
+    - show final result for verification
+
+    Must:
+    - deal with enforcement failures
+        - replace (and suggest default)
+        - change enforcement?
+    - deal with missing keys?
+    - set up input loop
+    - show finalized container for
+    - prompt for any patch fixes?
+    - deal with types of fields (mandatory, extraneous, etc)
+    """
+    target_name = target.__name__
+    print(f'Attempting to transfer {item.name} to {target_name}...')
+    # compare keys in item to target
+    matching_keys = [n for n in item.info_names
+                     if n in target.info_names]
+    item_exclusive = [n for n in item.info_names
+                      if n not in target.info_names]
+    target_exclusive = [n for n in target.info_names
+                        if n not in item.info_names]
+
+    pt = prettytable.PrettyTable()
+    pt.field_names = [f'{item.name}', f'{target_name}']
+    for n in matching_keys:
+        pt.add_row([n, n])
+    for ni in item_exclusive:
+        pt.add_row([ni, '-'])
+    for nt in target_exclusive:
+        pt.add_row(['-', nt])
+
+    click.echo(pt)
+
+    edits = {}
+    click.echo('\n----------Prepare Entries-----------')
+    # Deal with extra keys in item
+    for n in item_exclusive:
+        extra_prompt = (f'Include entry from {item.name}: '
+                        f'{n} = "{getattr(item, n)}"?')
+        if click.confirm(extra_prompt, default=True):
+            edits.update({n: getattr(item, n)})
+
+    # Deal with missing keys in target, deal with validation later
+    for nt in target_exclusive:
+        missing_prompt = (f'{target_name} expects information for '
+                          f'entry "{nt}"')
+        val = click.prompt(missing_prompt, default='take default')
+        if val != 'take default':
+            edits.update({nt: val})
+
+    # Actually apply changes and cast item into new container
+    # Enforce conditions are dealt with here
+    click.echo('\n----------Amend Entries-----------')
+    success = False
+    while not success:
+        success, res = change_container(item, target, edits=edits)
+        if not success:
+            fix_prompt = f'New value for "{res}"'
+            new_val = click.prompt(fix_prompt)
+            edits.update({res: new_val})
+
+    return res


### PR DESCRIPTION
## Description
- adds transfer cli tool
- adds transfer_container helper function with `click` user prompt 
- Fixes some EntryInfo exception messages

## Motivation and Context
closes #219 

## How Has This Been Tested?
Interactively, tests to come

## Where Has This Been Documented?
WIP

<details>
  <summary>Example CLI tool</summary>
  ```bash
(pcds-5.3.1)roberttk@psbuild-rhel7-01:~$ happi transfer at2l0 OphydItem
Attempting to transfer at2l0 to OphydItem...
+------------------+---------------+
|      at2l0       |   OphydItem   |
+------------------+---------------+
|       name       |      name     |
|   device_class   |  device_class |
|       args       |      args     |
|      kwargs      |     kwargs    |
|      active      |     active    |
|  documentation   | documentation |
|      prefix      |     prefix    |
|     beamline     |       -       |
|  location_group  |       -       |
| functional_group |       -       |
|        z         |       -       |
|      stand       |       -       |
|    lightpath     |       -       |
|   ioc_engineer   |       -       |
|   ioc_location   |       -       |
|    ioc_hutch     |       -       |
|   ioc_release    |       -       |
|     ioc_arch     |       -       |
|     ioc_name     |       -       |
|     ioc_type     |       -       |
+------------------+---------------+

----------Prepare Entries-----------
Include entry from at2l0: beamline = "LFEEEEEEEEEEEEEEEEEEEEEEE"? [Y/n]: y
Include entry from at2l0: location_group = "FEE"? [Y/n]: y
Include entry from at2l0: functional_group = "Attenuator"? [Y/n]: y
Include entry from at2l0: z = "734.5"? [Y/n]: y
Include entry from at2l0: stand = "L0S07"? [Y/n]: y
Include entry from at2l0: lightpath = "True"? [Y/n]: y
Include entry from at2l0: ioc_engineer = "None"? [Y/n]: n
Include entry from at2l0: ioc_location = "None"? [Y/n]: n
Include entry from at2l0: ioc_hutch = "None"? [Y/n]: n
Include entry from at2l0: ioc_release = "None"? [Y/n]: n
Include entry from at2l0: ioc_arch = "None"? [Y/n]: n
Include entry from at2l0: ioc_name = "None"? [Y/n]: n
Include entry from at2l0: ioc_type = "None"? [Y/n]: n

----------Amend Entries-----------
+------------------+-------------------------------------------+
| EntryInfo        | Value                                     |
+------------------+-------------------------------------------+
| active           | True                                      |
| args             | ['{{prefix}}']                            |
| beamline         | LFEEEEEEEEEEEEEEEEEEEEEEE                 |
| device_class     | pcdsdevices.attenuator.FEESolidAttenuator |
| documentation    | None                                      |
| functional_group | Attenuator                                |
| kwargs           | {'name': '{{name}}'}                      |
| lightpath        | True                                      |
| location_group   | FEE                                       |
| name             | at2l0                                     |
| prefix           | AT2L0:XTES                                |
| stand            | L0S07                                     |
| z                | 734.50000                                 |
+------------------+-------------------------------------------+
Save final device? [y/N]: y
[2022-05-12 17:14:29] - INFO -  Attempting to remove LCLSItem (name=at2l0) from the collection ...
[2022-05-12 17:14:29] - INFO -  Storing device OphydItem (name=at2l0) ...
[2022-05-12 17:14:29] - INFO -  Adding / Modifying information for at2l0 ...
[2022-05-12 17:14:29] - INFO -  HappiItem OphydItem (name=at2l0) has been succesfully added to the database
(pcds-5.3.1)roberttk@psbuild-rhel7-01:~$ happi search at2l0
+------------------+-------------------------------------------+
| EntryInfo        | Value                                     |
+------------------+-------------------------------------------+
| active           | True                                      |
| args             | ['{{prefix}}']                            |
| beamline         | LFEEEEEEEEEEEEEEEEEEEEEEE                 |
| creation         | Thu May 12 17:14:29 2022                  |
| device_class     | pcdsdevices.attenuator.FEESolidAttenuator |
| documentation    | None                                      |
| functional_group | Attenuator                                |
| kwargs           | {'name': '{{name}}'}                      |
| last_edit        | Thu May 12 17:14:29 2022                  |
| lightpath        | True                                      |
| location_group   | FEE                                       |
| name             | at2l0                                     |
| prefix           | AT2L0:XTES                                |
| stand            | L0S07                                     |
| type             | OphydItem                                 |
| z                | 734.50000                                 |
+------------------+-------------------------------------------+
  ```
</details>
