### PR TITLE
ENH: Refactor happi cli to use click instead of argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 
     # Extra dependencies needed to run the tests which are not included
     # at the recipe and dev-requirements.txt. E.g. PyQt
-    - CONDA_EXTRAS="pip"
+    - CONDA_EXTRAS=""
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 
     # Extra dependencies needed to run the tests which are not included
     # at the recipe and dev-requirements.txt. E.g. PyQt
-    - CONDA_EXTRAS=""
+    - CONDA_EXTRAS="pip"
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,6 @@ sphinx
 sphinx_rtd_theme
 psdm_qs_cli
 sphinx-click
-
 # PyPI's 2020 resolver can be problematic with these
 # dependencies-of-dependencies.  Constrain them here:
 six >=1.10.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,7 @@ mongomock >=3.22.0
 sphinx
 sphinx_rtd_theme
 psdm_qs_cli
-sphinx-argparse
+sphinx-click
 
 # PyPI's 2020 resolver can be problematic with these
 # dependencies-of-dependencies.  Constrain them here:

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -2,9 +2,6 @@
 Command Line Interface
 ===================================
 
-.. argparse::
-   :module: happi.cli
-   :func: get_parser
+.. click:: happi.cli:happi_cli
    :prog: happi
-   :nodescription:
-   :nodefault:
+   :nested: full

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
+    # sphinx_click: for 'click' directive (dep sphinx-click)
+    'sphinx_click',
     # sphinxarg: this is for the 'argparse' directive (dep sphinx-argparse)
     'sphinxarg.ext',
     'IPython.sphinxext.ipython_directive',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,8 +47,6 @@ extensions = [
     'sphinx.ext.autosummary',
     # sphinx_click: for 'click' directive (dep sphinx-click)
     'sphinx_click',
-    # sphinxarg: this is for the 'argparse' directive (dep sphinx-argparse)
-    'sphinxarg.ext',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
 ]

--- a/happi/__main__.py
+++ b/happi/__main__.py
@@ -1,0 +1,3 @@
+from happi.cli import main
+
+main()

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -22,11 +22,13 @@ from .utils import is_a_range, is_valid_identifier_not_keyword
 logger = logging.getLogger(__name__)
 
 version_msg = f'Happi: Version {happi.__version__} from {happi.__file__}'
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 @click.group(
     help=('commands available: search, add, edit, load, update, '
-          'container-registry, transfer')
+          'container-registry, transfer'),
+    context_settings=CONTEXT_SETTINGS
 )
 @click.option('--path', type=click.Path(exists=True),
               help='Provide the path to happi configuration file.')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -54,6 +54,8 @@ def happi_cli(ctx, path, verbose):
     logger.debug("Happi client: %r" % client)
 
     # insert items into context to be passed to subcommands
+    # User objects must be assigned to ctx.obj, which will be passed
+    # through to new context objects
     ctx.obj = client
 
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -228,6 +228,10 @@ def edit(ctx, name, edits):
 
     logger.debug('Starting edit block')
     device = client.find_device(name=name)
+    if len(edits) < 1:
+        click.echo('No edits provided, aborting')
+        raise click.Abort()
+
     for edit in edits:
         field, value = edit.split('=', 1)
         # validate field

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -58,12 +58,13 @@ def happi_cli(ctx, path, verbose):
 
 
 @happi_cli.command()
-@click.option('--json', is_flag=True, help='Show results in JSON format.')
+@click.option('--show_json', '-j', is_flag=True,
+              help='Show results in JSON format.')
 @click.option('--names', is_flag=True,
               help='Return results as whitespace-separated names.')
 @click.argument('search_criteria', nargs=-1)
 @click.pass_context
-def search(ctx, json, names, search_criteria):
+def search(ctx, show_json, names, search_criteria):
     """
     Search the happi database.  SEARCH_CRITERIA take the form: field=value.
     If 'field=' is omitted, it will assumed to be 'name'.
@@ -138,7 +139,7 @@ def search(ctx, json, names, search_criteria):
     else:
         final_results = []
 
-    if json:
+    if show_json:
         json.dump([dict(res.item) for res in final_results], indent=2,
                   fp=sys.stdout)
     elif names:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -6,7 +6,7 @@ import fnmatch
 import json
 import logging
 import os
-# allows arrow key navigation in prompt
+# on import allows arrow key navigation in prompt
 import readline  # noqa
 import sys
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -179,7 +179,7 @@ def add(ctx, clone):
         ctnr_prompt = (
             'Please select a container, or press enter for generic '
             f'Ophyd Device container: {os.linesep}{options}'
-            '{}{}Selection'.format(os.linesep, os.linesep)
+            f'{os.linesep}{os.linesep}Selection'
         )
         logger.debug(ctnr_prompt)
         response = click.prompt(ctnr_prompt, default='OphydItem')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 version_msg = f'Happi: Version {happi.__version__} from {happi.__file__}'
 
 
-@click.group()
+@click.group(
+    help=('commands available: search, add, edit, load, update, '
+          'container-registry, transfer')
+)
 @click.option('--path', type=click.Path(exists=True),
               help='Provide the path to happi configuration file.')
 @click.option('--verbose', '-v', is_flag=True,
@@ -59,7 +62,7 @@ def happi_cli(ctx, path, verbose):
 @click.pass_context
 def search(ctx, json, names, search_criteria):
     """
-    Search the happi database.  Search criteria of the form: field=value.
+    Search the happi database.  SEARCH_CRITERIA take the form: field=value.
     If 'field=' is omitted, it will assumed to be 'name'.
     You may include as many search criteria as you like; these will
     be combined with ANDs.
@@ -211,7 +214,7 @@ def add(ctx, clone):
 @click.pass_context
 def edit(ctx, name, edits):
     """
-    Change an existing entry by applying edits of the form: field=value
+    Change an existing entry by applying EDITS of the form: field=value
     to the item of name NAME.
     """
     # retrieve client

--- a/happi/errors.py
+++ b/happi/errors.py
@@ -1,3 +1,6 @@
+from click import UsageError
+
+
 class DatabaseError(Exception):
     """Raised when an database intitializes improperly."""
     pass
@@ -23,9 +26,10 @@ class SearchError(Exception):
     pass
 
 
-class EnforceError(ValueError):
+class EnforceError(ValueError, UsageError):
     """Raised when a value fails enforcement checks."""
-    pass
+    def __init__(self, message):
+        self.message = str(message)
 
 
 class TransferError(ValueError):

--- a/happi/item.py
+++ b/happi/item.py
@@ -126,7 +126,7 @@ class EntryInfo:
                 if self.enforce_doc:
                     raise EnforceError(self.enforce_doc) from e
                 else:
-                    raise e
+                    raise EnforceError(e)
 
         elif isinstance(self.enforce, (list, tuple, set)):
             # Check that value is in list, otherwise raise EnforceError
@@ -137,11 +137,16 @@ class EntryInfo:
 
         elif isinstance(self.enforce, Pattern):
             # Try and match regex patttern, otherwise raise EnforceError
-            if not self.enforce.match(value):
-                raise EnforceError(
-                    f'{self.key}={value!r} did not match the enforced pattern'
-                    f': ({self.enforce.pattern}). {self.enforce_doc}'
-                )
+            try:
+                if not self.enforce.match(value):
+                    raise EnforceError(
+                        f'{self.key}={value!r} did not match the enforced '
+                        f'pattern: ({self.enforce.pattern}). '
+                        f'{self.enforce_doc}'
+                    )
+            except TypeError as e:
+                raise EnforceError(e)
+
             return value
 
         # Invalid enforcement

--- a/happi/prompt.py
+++ b/happi/prompt.py
@@ -14,7 +14,9 @@ hopefully_unique_keyword = 'verylonghopefullyuniquekeywordthatdoesnotconflict'
 
 
 def read_user_dict(prompt, default: Optional[dict] = None):
-
+    """
+    Prompt for a dictionary, prompting for keys and values separately
+    """
     user_dict = {}
     click.echo(prompt + '\nKey must be a string.  ' +
                'Enter a blank key to complete dict entry.')
@@ -25,7 +27,12 @@ def read_user_dict(prompt, default: Optional[dict] = None):
                            value_proc=is_valid_identifier_not_keyword)
         if key is hopefully_unique_keyword:
             break
+
         value = click.prompt('  value')
+        try:
+            value = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            logger.debug(f'Taking {value} as a string')
 
         user_dict.update({key: value})
 

--- a/happi/prompt.py
+++ b/happi/prompt.py
@@ -1,11 +1,79 @@
+import ast
 import logging
+from typing import Optional
 
 import click
 import prettytable
 
 from happi.errors import TransferError
+from happi.utils import OptionalDefault, is_valid_identifier_not_keyword
 
 logger = logging.getLogger(__name__)
+
+hopefully_unique_keyword = 'verylonghopefullyuniquekeywordthatdoesnotconflict'
+
+
+def read_user_dict(prompt, default: Optional[dict] = None):
+
+    user_dict = {}
+    click.echo(prompt + '\nKey must be a string.  ' +
+               'Enter a blank key to complete dict entry.')
+    while True:
+        key = click.prompt('  key',
+                           default=hopefully_unique_keyword,
+                           show_default=False,
+                           value_proc=is_valid_identifier_not_keyword)
+        if key is hopefully_unique_keyword:
+            break
+        value = click.prompt('  value')
+
+        user_dict.update({key: value})
+
+    if not user_dict:
+        return default
+
+    return user_dict
+
+
+def prompt_for_entry(entry_info, clone_source=None):
+    """Prompt for an entry based on the entry_info provided"""
+    if clone_source:
+        default = getattr(clone_source, entry_info.key)
+    else:
+        default = entry_info.default
+
+    if entry_info.optional and (default is None):
+        # Prompt will continue to prompt if default is None
+        # Provide a dummy value to allow prompt to exit
+        default = OptionalDefault()
+    enforce_str = getattr(entry_info.enforce, '__name__',
+                          str(entry_info.enforce))
+    val_prompt = (f'Enter value for {entry_info.key}, '
+                  f'enforce={enforce_str}')
+
+    if entry_info.enforce is list:
+        logger.debug('prompting for list')
+        value = click.prompt(val_prompt, default=str(default),
+                             value_proc=ast.literal_eval)
+    elif entry_info.enforce is dict:
+        # TODO: deal with dict parsing.  Could work in similar way but
+        # likely requires a separate methodology...
+        logger.debug('prompting for dict')
+        value = read_user_dict(val_prompt, default=default)
+    elif entry_info.enforce is bool:
+        logger.debug('prompting for bool')
+        # coerces into y or n, preventing random strings (eg. 'f') from
+        # evaluating as True
+        value = click.confirm(val_prompt, default=default)
+    else:
+        value = click.prompt(val_prompt, default=default,
+                             value_proc=entry_info.enforce)
+
+    if isinstance(value, OptionalDefault):
+        # Default was None, return None
+        value = None
+
+    return value
 
 
 def transfer_container(client, item, target):

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -97,9 +97,7 @@ def trim_split_output(strings, delim='\n'):
     """
     date_pattern = r"\[(\d{4})[-](0[1-9]|1[012])[-].*\]"
 
-    bad_substrs = [
-        r"^pcdsdevices"
-    ]
+    bad_substrs = [r"^pcdsdevices"]
 
     # remove registry items
     new_out = [
@@ -120,14 +118,6 @@ def assert_match_expected(result, expected_output):
     trimmed_output = trim_split_output(result.output)
     for message, expected in zip(trimmed_output, expected_output):
         assert message == expected
-
-
-def test_cli_version(runner):
-    result = runner.invoke(happi_cli, ['--version'])
-    assert result.exit_code == 0
-    assert result.exception is None
-    assert happi.__version__ in result.output
-    assert happi.__file__ in result.output
 
 
 def test_cli_no_argument(runner):

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -191,6 +191,42 @@ def test_both_range_and_regex_search(client):
     assert [r.item for r in res] == [r.item for r in res_cli]
 
 
+def test_search_json(runner, happi_cfg):
+    expected_output = '''[
+  {
+    "name": "tst_base_pim2",
+    "device_class": "types.SimpleNamespace",
+    "args": [
+      "{{prefix}}"
+    ],
+    "kwargs": {
+      "name": "{{name}}"
+    },
+    "active": true,
+    "documentation": null,
+    "prefix": "TST:BASE:PIM2",
+    "_id": "TST_BASE_PIM2",
+    "beamline": "TST",
+    "creation": "Wed Jan 30 09:46:00 2019",
+    "last_edit": "Fri Apr 13 14:40:08 2018",
+    "macros": null,
+    "parent": null,
+    "screen": null,
+    "stand": "BAS",
+    "system": "diagnostic",
+    "type": "OphydItem",
+    "z": 6.0
+  }
+]'''
+
+    result = runner.invoke(
+        happi_cli, ['--path', happi_cfg, 'search', '-j', 'TST_BASE_PIM2']
+    )
+
+    assert result.exit_code == 0
+    assert_match_expected(result, expected_output.split('\n'))
+
+
 @pytest.mark.parametrize("from_user, expected_output", [
     # Test add item - succeeding
     pytest.param('\n'.join(['HappiItem', 'happi_nname', 'device_class',

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -2,13 +2,15 @@
 
 import builtins
 import logging
+import re
 from unittest import mock
 
 import IPython
 import pytest
+from click.testing import CliRunner
 
 import happi
-from happi.cli import happi_cli
+from happi.cli import happi_cli, search
 from happi.errors import SearchError
 
 
@@ -79,195 +81,280 @@ def db(tmp_path):
     return str(json_path.absolute())
 
 
-def test_cli_version(capsys):
-    happi_cli(['--version'])
-    readout = capsys.readouterr()
-    assert happi.__version__ in readout.out
-    assert happi.__file__ in readout.out
+@pytest.fixture(scope='function')
+def runner():
+    return CliRunner()
 
 
-def test_cli_no_argument(capsys):
-    happi.cli.happi_cli([])
-    readout = capsys.readouterr()
-    assert 'usage:' in readout.out
+@pytest.fixture(scope='function')
+def client(happi_cfg):
+    return happi.client.Client.from_config(cfg=happi_cfg)
 
 
-def test_search(happi_cfg):
-    client = happi.client.Client.from_config(cfg=happi_cfg)
+def trim_split_output(strings, delim='\n'):
+    """
+    Trim output of timestamped messages and registry lists.
+    Split on delimiter (newline by default)
+    """
+    date_pattern = r"\[(\d{4})[-](0[1-9]|1[012])[-].*\]"
+
+    bad_substrs = [
+        r"^pcdsdevices"
+    ]
+
+    # remove registry items
+    new_out = [
+        st for st in strings.split(delim)
+        if not any([re.search(substr, st) for substr in bad_substrs])
+    ]
+
+    # string date-time from logging messages
+    new_out = [re.sub(date_pattern, '', st) for st in new_out]
+    return new_out
+
+
+def assert_match_expected(result, expected_output):
+    """standard checks for a cli result, confirms output matches expected"""
+    assert result.exit_code == 0
+    assert not result.exception
+
+    trimmed_output = trim_split_output(result.output)
+    for message, expected in zip(trimmed_output, expected_output):
+        assert message == expected
+
+
+def test_cli_version(runner):
+    result = runner.invoke(happi_cli, ['--version'])
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert happi.__version__ in result.outut
+    assert happi.__file__ in result.output
+
+
+def test_cli_no_argument(runner):
+    result = runner.invoke(happi_cli)
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert 'Usage:' in result.output
+    assert 'Options:' in result.output
+    assert 'Commands:' in result.output
+
+
+def test_search(client):
     res = client.search_regex(beamline="TST")
-    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
-                                   'beamline=TST'])
+
+    with search.make_context('search', ['beamline=TST'], obj=client) as ctx:
+        res_cli = search.invoke(ctx)
+
     assert [r.device for r in res] == [r.device for r in res_cli]
 
 
-def test_search_with_name(happi_cfg, caplog):
-    client = happi.client.Client.from_config(cfg=happi_cfg)
+def test_search_with_name(client, caplog):
     res = client.search_regex(name='TST_BASE_PIM2')
-    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
-                                   'TST_BASE_PIM2'])
+
+    with search.make_context('search', ['TST_BASE_PIM2'], obj=client) as ctx:
+        res_cli = search.invoke(ctx)
+
     assert [r.device for r in res] == [r.device for r in res_cli]
     # test duplicate search parameters
     with caplog.at_level(logging.ERROR):
-        res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg,
-                                       'search', 'TST_BASE_PIM2',
-                                       'name=TST_BASE_PIM2'])
-        assert "Received duplicate search criteria" in caplog.text
-        caplog.clear()
+        with search.make_context('search', ['TST_BASE_PIM2',
+                                 'name=TST_BASE_PIM2'],
+                                 obj=client) as ctx:
+            res_cli = search.invoke(ctx)
+
+    assert "Received duplicate search criteria" in caplog.text
 
 
-def test_search_z(happi_cfg):
-    client = happi.client.Client.from_config(cfg=happi_cfg)
+def test_search_z(client):
     res = client.search_regex(z="6.0")
-    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
-                                   'z=6.0'])
+    with search.make_context('search', ['z=6.0'], obj=client) as ctx:
+        res_cli = search.invoke(ctx)
+
     assert [r.device for r in res] == [r.device for r in res_cli]
 
 
-def test_search_z_range(happi_cfg, caplog):
-    client = happi.client.Client.from_config(cfg=happi_cfg)
+def test_search_z_range(client, caplog):
     res = client.search_range('z', 3.0, 6.0)
-    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
-                                   'z=3.0,6.0'])
+
+    with search.make_context('search', ['z=3.0,6.0'], obj=client) as ctx:
+        res_cli = search.invoke(ctx)
+
     assert [r.device for r in res] == [r.device for r in res_cli]
     # test invalid range
     with caplog.at_level(logging.ERROR):
-        res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg,
-                                       'search', 'z=6.0,3.0'])
+        with search.make_context('search', ['z=6.0,3.0'], obj=client) as ctx:
+            res_cli = search.invoke(ctx)
+
         assert "Invalid range, make sure start < stop" in caplog.text
         caplog.clear()
 
 
-def test_both_range_and_regex_search(happi_cfg):
-    client = happi.client.Client.from_config(cfg=happi_cfg)
+def test_both_range_and_regex_search(client):
     # we're only interested in getting this entry (TST_BASE_PIM2)
     res = client.search_regex(z='6.0')
     # we're going to search for z=3,7 name=TST_BASE_PIM2
     # we should only get in return one entry, even though the z value found 2
-    res_cli = happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'search',
-                                   'name=TST_BASE_PIM2', 'z=3.0,7.0'])
+    with search.make_context('search', ['name=TST_BASE_PIM2', 'z=3.0,7.0'],
+                             obj=client) as ctx:
+        res_cli = search.invoke(ctx)
+
     assert [r.device for r in res] == [r.device for r in res_cli]
 
 
 @pytest.mark.parametrize("from_user, expected_output", [
     # Test add item - succeeding
-    pytest.param(['HappiItem', 'happi_name', 'device_class', ['arg1', 'arg2'],
-                  {'name': 'my_name'}, True, 'docs', 'y'], [
-        "Please select a container, or press enter for generic "
-        "Ophyd Device container",
-        "Enter value for name, default=None, "
-        "enforce=re.compile('[a-z][a-z\\\\_0-9]{2,78}$')",
-        "Enter value for device_class, default=None, enforce=<class 'str'>",
-        "Enter value for args, default=[], enforce=<class 'list'>",
-        "Enter value for kwargs, default={}, enforce=<class 'dict'>",
-        "Enter value for active, default=True, enforce=<class 'bool'>",
-        "Enter value for documentation, default=None, enforce=<class 'str'>",
-        "Please confirm the following info is correct:",
-        "Adding device",
-        "Storing device HappiItem (name=happi_name) ...",
-        "Adding / Modifying information for happi_name ...",
-        "HappiItem HappiItem (name=happi_name) has been "
-        "succesfully added to the database"],
+    pytest.param('\n'.join(['HappiItem', 'happi_nname', 'device_class',
+                            '', '', 'Y', 'docs', 'y']), (
+        'Please select a container, or press enter for generic '
+        'Ophyd Device container: ', 'OphydItem', 'HappiItem', '',
+        'Selection [OphydItem]: HappiItem',
+        'Enter value for name, enforce=is_valid_identifier_not_keyword: '
+        'happi_nname',
+        'Selecting value: happi_nname',
+        'Enter value for device_class, enforce=str [optional]: '
+        'device_class',
+        'Selecting value: device_class',
+        'Enter value for args, enforce=list [[]]: ',
+        'Selecting value: []',
+        'Enter value for kwargs, enforce=dict',
+        'Key must be a string.  Enter a blank key to complete dict entry.',
+        '  key: ', 'Selecting value: {}',
+        'Enter value for active, enforce=bool [Y/n]: Y',
+        'Selecting value: True',
+        'Enter value for documentation, enforce=str [optional]: docs',
+        'Selecting value: docs',
+        'Please confirm the device info is correct [y/N]: y',
+        ' - INFO -  Adding device',
+        ' - INFO -  Storing device HappiItem (name=happi_nname) ...',
+        ' - INFO -  Adding / Modifying information for happi_nname ...',
+        ' - INFO -  HappiItem HappiItem (name=happi_nname) has been '
+        'succesfully added to the database'),
     ),
     # Test add item - aborting
-    pytest.param(['HappiItem', 'happi_name2', 'device_class', ['arg1', 'arg2'],
-                  {'name': 'my_name'}, True, 'docs', 'N'], [
-        "Please select a container, or press enter for generic "
-        "Ophyd Device container",
-        "Enter value for name, default=None, "
-        "enforce=re.compile('[a-z][a-z\\\\_0-9]{2,78}$')",
-        "Enter value for device_class, default=None, enforce=<class 'str'>",
-        "Enter value for args, default=[], enforce=<class 'list'>",
-        "Enter value for kwargs, default={}, enforce=<class 'dict'>",
-        "Enter value for active, default=True, enforce=<class 'bool'>",
-        "Enter value for documentation, default=None, enforce=<class 'str'>",
-        "Please confirm the following info is correct:",
-        "Aborting"],
+    pytest.param('\n'.join(['HappiItem', 'happi_name2', 'device_class',
+                            '["arg1", "arg2"]', 'name', 'my_name', '',
+                            'Y', 'docs', 'N']), (
+        'Please select a container, or press enter for generic '
+        'Ophyd Device container: ', 'OphydItem', 'HappiItem', '',
+        'Selection [OphydItem]: HappiItem',
+        'Enter value for name, enforce=is_valid_identifier_not_keyword: '
+        'happi_name2',
+        'Selecting value: happi_name2',
+        'Enter value for device_class, enforce=str [optional]: '
+        'device_class',
+        'Selecting value: device_class',
+        'Enter value for args, enforce=list [[]]: ["arg1", "arg2"]',
+        "Selecting value: ['arg1', 'arg2']",
+        'Enter value for kwargs, enforce=dict',
+        'Key must be a string.  Enter a blank key to complete dict entry.',
+        '  key: name', '  value: my_name', '  key: ',
+        "Selecting value: {'name': 'my_name'}",
+        'Enter value for active, enforce=bool [Y/n]: Y',
+        'Selecting value: True',
+        'Enter value for documentation, enforce=str [optional]: docs',
+        'Selecting value: docs',
+        'Please confirm the device info is correct [y/N]: N',
+        ' - INFO -  Aborting'),
     ),
     # Test add item - invalid container
-    pytest.param(['HappiInvalidItem'], [
-        "Please select a container, or press enter for generic "
-        "Ophyd Device container",
-        "Invalid device container"],
+    pytest.param('HappiInvalidItem', (
+        'Please select a container, or press enter for generic '
+        'Ophyd Device container: ', 'OphydItem', 'HappiItem', '',
+        'Selection [OphydItem]: HappiInvalidItem',
+        ' - INFO -  Invalid device container HappiInvalidItem'),
     ),
     # Test add item - no reponse, not an optional field,
     # invalid value, add OphydItem
-    pytest.param(['', 7, 'ophyd_name', 'device_class', ['arg1', 'arg2'],
-                  {'name': 'my_name'}, True, 'docs', '', 'some_prefix', 'y'], [
-        "Please select a container, or press enter for generic "
-        "Ophyd Device container",
-        "Enter value for name, default=None, "
-        "enforce=re.compile('[a-z][a-z\\\\_0-9]{2,78}$')",
-        "Invalid value",
-        "Enter value for name, default=None, "
-        "enforce=re.compile('[a-z][a-z\\\\_0-9]{2,78}$')",
-        "Enter value for device_class, default=None, enforce=<class 'str'>",
-        "Enter value for args, default=['{{prefix}}'], enforce=<class 'list'>",
-        "Enter value for kwargs, default={'name': '{{name}}'}, "
-        "enforce=<class 'dict'>",
-        "Enter value for active, default=True, enforce=<class 'bool'>",
-        "Enter value for documentation, default=None, enforce=<class 'str'>",
-        "Enter value for prefix, default=None, enforce=<class 'str'>",
-        "Not an optional field!",
-        "Enter value for prefix, default=None, enforce=<class 'str'>",
-        "Please confirm the following info is correct:",
-        "Adding device",
-        "Storing device OphydItem (name=ophyd_name) ...",
-        "Adding / Modifying information for ophyd_name ...",
-        "HappiItem OphydItem (name=ophyd_name) has been "
-        "succesfully added to the database"],
+    pytest.param('\n'.join(['', '7', 'ophyd_name', 'device_class',
+                            "['arg1', 'arg2']", 'name', 'my_name', '',
+                            'Y', 'docs', '', 'some_prefix', 'y']), (
+        'Please select a container, or press enter for generic '
+        'Ophyd Device container: ', 'OphydItem', 'HappiItem', '',
+        'Selection [OphydItem]: ',
+        'Enter value for name, enforce=is_valid_identifier_not_keyword: 7',
+        'Error: 7 is either not a valid Python identifier, or is a '
+        'reserved keyword.',
+        'Enter value for name, enforce=is_valid_identifier_not_keyword: '
+        'ophyd_name',
+        'Selecting value: ophyd_name',
+        'Enter value for device_class, enforce=str [optional]: device_class',
+        'Selecting value: device_class',
+        "Enter value for args, enforce=list [['{{prefix}}']]: "
+        "['arg1', 'arg2']", "Selecting value: ['arg1', 'arg2']",
+        'Enter value for kwargs, enforce=dict',
+        'Key must be a string.  Enter a blank key to complete dict entry.',
+        '  key: name', '  value: my_name', '  key: ',
+        "Selecting value: {'name': 'my_name'}",
+        'Enter value for active, enforce=bool [Y/n]: Y',
+        'Selecting value: True',
+        'Enter value for documentation, enforce=str [optional]: docs',
+        'Selecting value: docs',
+        'Enter value for prefix, enforce=str: ',
+        'Enter value for prefix, enforce=str: some_prefix',
+        'Selecting value: some_prefix',
+        'Please confirm the device info is correct [y/N]: y',
+        ' - INFO -  Adding device',
+        ' - INFO -  Storing device OphydItem (name=ophyd_name) ...',
+        ' - INFO -  Adding / Modifying information for ophyd_name ...',
+        ' - INFO -  HappiItem OphydItem (name=ophyd_name) has been '
+        'succesfully added to the database'
+         ),
     ),
     ], ids=["add_succeeding", "add_aborting",
             "add_invalid_container", "add_not_optional_field"])
-def test_add_cli(from_user, expected_output, caplog, happi_cfg):
-    with mock.patch.object(builtins, 'input', lambda x=None: from_user.pop(0)):
-        happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'add'])
-        caplog.clear()
-        for message, expected in zip(caplog.messages, expected_output):
-            assert expected in message
+def test_add_cli(from_user, expected_output, caplog, runner, happi_cfg):
+    result = runner.invoke(happi_cli, ['--path', happi_cfg, 'add'],
+                           input=from_user)
+    assert_match_expected(result, expected_output)
 
 
 @pytest.mark.parametrize("from_user, expected_output", [
     # Test add --clone item - succeeding
-    pytest.param(['happi_new_name', 'device_class', ['arg1', 'arg2'],
-                  {'name': 'my_name'}, True, '', 'y'], [
-        "Enter value for name, default=happi_name, "
-        "enforce=re.compile('[a-z][a-z\\\\_0-9]{2,78}$')",
-        "Enter value for device_class, default=device_class, "
-        "enforce=<class 'str'>",
-        "Enter value for args, default=['arg1', 'arg2'], "
-        "enforce=<class 'list'>",
-        "Enter value for kwargs, default={'name': 'my_name'}, "
-        "enforce=<class 'dict'>",
-        "Enter value for active, default=True, enforce=<class 'bool'>",
-        "Enter value for documentation, default=docs, enforce=<class 'str'>",
-        "Selecting default value docs",
-        "Please confirm the following info is correct:",
-        "Adding device",
-        "Storing device HappiItem (name=happi_new_name) ...",
-        "Adding / Modifying information for happi_new_name ...",
-        "HappiItem HappiItem (name=happi_new_name) has been "
-        "succesfully added to the database"], id="clone_succeeding",
+    pytest.param('\n'.join(['happi_new_name', 'device_class',
+                            "['arg1', 'arg2']", 'name', 'my_name', '',
+                            '', '', 'y']), [
+        'Enter value for name, enforce=is_valid_identifier_not_keyword '
+        '[happi_name]: happi_new_name', 'Selecting value: happi_new_name',
+        'Enter value for device_class, enforce=str [device_class]: '
+        'device_class', 'Selecting value: device_class',
+        "Enter value for args, enforce=list [['arg1', 'arg2']]: "
+        "['arg1', 'arg2']", "Selecting value: ['arg1', 'arg2']",
+        'Enter value for kwargs, enforce=dict',
+        'Key must be a string.  Enter a blank key to complete dict entry.',
+        '  key: name', '  value: my_name', '  key: ',
+        "Selecting value: {'name': 'my_name'}", 'Enter value for active, '
+        'enforce=bool [Y/n]: ', 'Selecting value: True',
+        'Enter value for documentation, enforce=str [docs]: ',
+        'Selecting value: docs', 'Please confirm the device info is '
+        'correct [y/N]: y', ' - INFO -  Adding device',
+        ' - INFO -  Storing device HappiItem (name=happi_new_name) ...',
+        ' - INFO -  Adding / Modifying information for happi_new_name ...',
+        ' - INFO -  HappiItem HappiItem (name=happi_new_name) has been '
+        'succesfully added to the database', ''], id="clone_succeeding",
     )])
-def test_add_clone(from_user, expected_output, caplog, happi_cfg):
-    device_info = ['HappiItem', 'happi_name', 'device_class',
-                   ['arg1', 'arg2'], {'name': 'my_name'}, True, 'docs', 'y']
-    with mock.patch.object(
-            builtins, 'input', lambda x=None: device_info.pop(0)):
-        # add device first
-        happi.cli.happi_cli(['--verbose', '--path', happi_cfg, 'add'])
-    with mock.patch.object(builtins, 'input', lambda x=None: from_user.pop(0)):
-        # try to clone from previously added device
-        happi.cli.happi_cli(
-            ['--verbose', '--path', happi_cfg, 'add', '--clone', 'happi_name'])
-        caplog.clear()
-        for message, expected in zip(caplog.messages, expected_output):
-            assert expected in message
+def test_add_clone(from_user, expected_output, happi_cfg, runner):
+    device_info = '\n'.join(['HappiItem', 'happi_name', 'device_class',
+                             "['arg1', 'arg2']", 'name', 'my_name', '',
+                             'Y', 'docs', 'y'])
+    # add device first
+    add_result = runner.invoke(happi_cli, ['--path', happi_cfg, 'add'],
+                               input=device_info)
+    assert add_result.exit_code == 0
+
+    clone_result = runner.invoke(
+        happi_cli, ['--path', happi_cfg, 'add', '--clone', 'happi_name'],
+        input=from_user)
+
+    assert_match_expected(clone_result, expected_output)
 
 
-def test_add_clone_device_not_fount(happi_cfg):
-    with pytest.raises(SearchError):
-        happi.cli.happi_cli(
-            ['--verbose', '--path', happi_cfg, 'add', '--clone', 'happi_name'])
+def test_add_clone_device_not_fount(happi_cfg, runner):
+    result = runner.invoke(
+        happi_cli,
+        ['--verbose', '--path', happi_cfg, 'add', '--clone', 'happi_name']
+    )
+    assert isinstance(result.exception, SearchError)
 
 
 @pytest.mark.parametrize("from_user, expected_output", [
@@ -353,3 +440,41 @@ def test_update(happi_cfg):
     client = happi.client.Client.from_config(cfg=happi_cfg)
     item = client.find_device(name="tst_base_pim2")
     assert item["from_update"]
+
+
+@pytest.mark.parametrize("from_user, expected_output", [
+    pytest.param('\n'.join(['n', 'n', 'n', 'n', 'N', 'n', 'n', '']), [
+        'Attempting to transfer tst_base_pim to OphydItem...',
+        '+---------------+---------------+',
+        '|  tst_base_pim |   OphydItem   |',
+        '+---------------+---------------+',
+        '|     active    |     active    |',
+        '|      args     |      args     |',
+        '|  device_class |  device_class |',
+        '| documentation | documentation |',
+        '|     kwargs    |     kwargs    |',
+        '|      name     |      name     |',
+        '|     prefix    |     prefix    |',
+        '|    beamline   |       -       |',
+        '|     macros    |       -       |',
+        '|     parent    |       -       |',
+        '|     screen    |       -       |',
+        '|     stand     |       -       |',
+        '|     system    |       -       |',
+        '|       z       |       -       |',
+        '+---------------+---------------+', '',
+        '----------Prepare Entries-----------',
+        'Include entry from tst_base_pim: beamline = "TST"? [Y/n]: n',
+        'Include entry from tst_base_pim: macros = "None"? [Y/n]: n',
+        'Include entry from tst_base_pim: parent = "None"? [Y/n]: n',
+        'Include entry from tst_base_pim: screen = "None"? [Y/n]: n',
+        'Include entry from tst_base_pim: stand = "BAS"? [Y/n]: N',
+        'Include entry from tst_base_pim: system = "diagnostic"? [Y/n]: n',
+        'Include entry from tst_base_pim: z = "3.0"? [Y/n]: n', '',
+        '----------Amend Entries-----------', 'Save final device? [y/N]: ',
+        ''], id="transfer_succeeding",
+    )])
+def test_transfer_cli(from_user, expected_output, happi_cfg, runner):
+    results = runner.invoke(happi_cli, ['--path', happi_cfg, 'transfer',
+                            'tst_base_pim', 'OphydItem'], input=from_user)
+    assert_match_expected(results, expected_output)

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -135,7 +135,7 @@ def test_search(client):
     with search.make_context('search', ['beamline=TST'], obj=client) as ctx:
         res_cli = search.invoke(ctx)
 
-    assert [r.device for r in res] == [r.device for r in res_cli]
+    assert [r.item for r in res] == [r.item for r in res_cli]
 
 
 def test_search_with_name(client, caplog):
@@ -144,7 +144,7 @@ def test_search_with_name(client, caplog):
     with search.make_context('search', ['TST_BASE_PIM2'], obj=client) as ctx:
         res_cli = search.invoke(ctx)
 
-    assert [r.device for r in res] == [r.device for r in res_cli]
+    assert [r.item for r in res] == [r.item for r in res_cli]
     # test duplicate search parameters
     with caplog.at_level(logging.ERROR):
         with search.make_context('search', ['TST_BASE_PIM2',
@@ -160,7 +160,7 @@ def test_search_z(client):
     with search.make_context('search', ['z=6.0'], obj=client) as ctx:
         res_cli = search.invoke(ctx)
 
-    assert [r.device for r in res] == [r.device for r in res_cli]
+    assert [r.item for r in res] == [r.item for r in res_cli]
 
 
 def test_search_z_range(client, caplog):
@@ -169,7 +169,7 @@ def test_search_z_range(client, caplog):
     with search.make_context('search', ['z=3.0,6.0'], obj=client) as ctx:
         res_cli = search.invoke(ctx)
 
-    assert [r.device for r in res] == [r.device for r in res_cli]
+    assert [r.item for r in res] == [r.item for r in res_cli]
     # test invalid range
     with caplog.at_level(logging.ERROR):
         with search.make_context('search', ['z=6.0,3.0'], obj=client) as ctx:
@@ -188,7 +188,7 @@ def test_both_range_and_regex_search(client):
                              obj=client) as ctx:
         res_cli = search.invoke(ctx)
 
-    assert [r.device for r in res] == [r.device for r in res_cli]
+    assert [r.item for r in res] == [r.item for r in res_cli]
 
 
 @pytest.mark.parametrize("from_user, expected_output", [

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -4,6 +4,8 @@ Basic module utilities
 import keyword
 import logging
 
+from happi.errors import EnforceError
+
 logger = logging.getLogger(__name__)
 
 
@@ -63,5 +65,11 @@ def is_valid_identifier_not_keyword(str_value):
             return str_value
     except Exception:
         pass
-    raise ValueError(f'{str_value} is either not a valid Python identifier, '
-                     'or is a reserved keyword.')
+    raise EnforceError(f'{str_value} is either not a valid Python identifier, '
+                       'or is a reserved keyword.')
+
+
+class OptionalDefault():
+    """Dummy object to pass to click.prompt if there is no default"""
+    def __str__(self):
+        return 'optional'

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -77,3 +77,13 @@ class OptionalDefault():
     """
     def __str__(self):
         return 'optional'
+
+
+def optional_enforce(enforce_value):
+    def inner(value):
+        if isinstance(value, OptionalDefault):
+            return value
+        else:
+            return enforce_value(value)
+
+    return inner

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -70,6 +70,10 @@ def is_valid_identifier_not_keyword(str_value):
 
 
 class OptionalDefault():
-    """Dummy object to pass to click.prompt if there is no default"""
+    """
+    Dummy object to pass to click.prompt if there is no default
+
+    Simply meant to be unique, to avoid collisions with real defaults
+    """
     def __str__(self):
         return 'optional'

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,4 @@ setup(name='happi',
       include_package_data=True,
       install_requires=requirements,
       description='Happi Database Access for LCLS Beamline Devices',
-      entry_points={'console_scripts': ['happi=happi.cli:main']})
+      entry_points={'console_scripts': ['happi=happi.cli:happi_cli']})


### PR DESCRIPTION
## Description
A rather long PR, which initially started as an effort to simplify our cli code base using `click`, but started to tackle broken/missing functionality along the way.  An effort has been made to preserve existing functionality, except where existing functionality was broken.  

### Enhancements:
- Refactors happi_cli into a click command group, with subcommands (search, add, etc)
- Reworks tests to use click.testing.CliRunner, which keeps track of exit code, exception, and stdout/stderr
- Adds various helpers along the way
- Enforce values received in `happi edit`, and properly handle dicts/lists

### Bug fixes:
- Fixes user-input dictionaries and lists to actually work (issue here?)

## Motivation and Context
The CLI interface has needed some touching up, particularly in the user-prompting side of things.  Users often edit the json directly, and while this may be more direct, it's more prone to error.  If happi provides a good interface for this, perhaps we can preempt some of these errors

Fun notes:
- `click.prompt` has built in type checking and conversion, which lines up very well with `EntryInfo.enforce`.  
- `click.testing.CliRunner` keeps track of exit code, exceptions, and output.  The output capturing actually happens before capsys, but caplog still works.  
- subcommands get passed a `Context` from the main invoking group (in this case `happi_cli`).  To run commands individually, you must create this context manually.  This is what is done in some of the search tests.  In most cases, you can just invoke the main command.  


## How Has This Been Tested?
Test suite has been reworked.  Interactive testing along the way

## Where Has This Been Documented?
Docstrings and this PR
