### PR TITLE
TST/MNT: Fix tests, add pre-release notes

### DIFF
--- a/docs/pre-release-notes.sh
+++ b/docs/pre-release-notes.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ISSUE=$1
+shift
+DESCRIPTION=$*
+
+if [[ -z "$ISSUE" || -z "$DESCRIPTION" ]]; then
+    echo "Usage: $0 (ISSUE NUMBER) (DESCRIPTION)"
+    exit 1
+fi
+
+echo "Issue: $ISSUE"
+echo "Description: $DESCRIPTION"
+
+FILENAME=source/upcoming_release_notes/${ISSUE}-${DESCRIPTION// /_}.rst
+
+pushd "$(dirname "$0")" || exit 1
+
+sed -e "s/IssueNumber Title/${ISSUE} ${DESCRIPTION}/" \
+    "source/upcoming_release_notes/template-short.rst" > "${FILENAME}"
+
+if ${EDITOR} "${FILENAME}"; then
+    echo "Adding ${FILENAME} to the git repository..."
+    git add "${FILENAME}"
+fi
+
+popd

--- a/docs/release_notes.py
+++ b/docs/release_notes.py
@@ -1,0 +1,93 @@
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+# find the pre-release directory and release notes file
+THIS_DIR = Path(__file__).resolve().parent
+PRE_RELEASE = THIS_DIR / 'source' / 'upcoming_release_notes'
+TEMPLATE = PRE_RELEASE / 'template-short.rst'
+RELEASE_NOTES = THIS_DIR / 'source' / 'releases.rst'
+
+# Set up underline constants
+TITLE_UNDER = '#'
+RELEASE_UNDER = '='
+SECTION_UNDER = '-'
+
+def parse_pre_release_file(path):
+    """
+    Return dict mapping of release notes section to lines.
+
+    Uses empty list when no info was entered for the section.
+    """
+    print(f'Checking {path} for release notes.')
+    with path.open('r') as fd:
+        lines = fd.readlines()
+
+    section_dict = defaultdict(list)
+    prev = None
+    section = None
+
+    for line in lines:
+        if prev is not None:
+            if line.startswith(SECTION_UNDER * 2):
+                section = prev.strip()
+                continue
+            if section is not None and line[0] in ' -':
+                notes = section_dict[section]
+                if len(line) > 6:
+                    notes.append(line)
+                section_dict[section] = notes
+        prev = line
+
+    return section_dict
+
+
+def extend_release_notes(path, version, release_notes):
+    """
+    Given dict mapping of section to lines, extend the release notes file.
+    """
+    with path.open('r') as fd:
+        lines = fd.readlines()
+
+    new_lines = ['\n', '\n']
+    date = time.strftime('%Y-%m-%d')
+    release_title = f'{version} ({date})'
+    new_lines.append(release_title + '\n')
+    new_lines.append(len(release_title) * RELEASE_UNDER + '\n')
+    new_lines.append('\n')
+    for section, section_lines in release_notes.items():
+        if section == 'Contributors':
+            section_lines = sorted(list(set(section_lines)))
+        if len(section_lines) > 0:
+            new_lines.append(section + '\n')
+            new_lines.append(SECTION_UNDER * len(section) + '\n')
+            new_lines.extend(section_lines)
+            new_lines.append('\n')
+
+    output_lines = lines[:2] + new_lines + lines[2:]
+
+    print('Writing out release notes file')
+    for line in new_lines:
+        print(line.strip('\n'))
+    with path.open('w') as fd:
+        fd.writelines(output_lines)
+
+
+def main(version):
+    section_notes = parse_pre_release_file(TEMPLATE)
+    for path in PRE_RELEASE.iterdir():
+        if path.name[0] in '1234567890':
+            extra_notes = parse_pre_release_file(path)
+            for section, notes in section_notes.items():
+                notes.extend(extra_notes[section])
+                section_notes[section] = notes
+
+    extend_release_notes(RELEASE_NOTES, version, section_notes)
+
+    # git rm all of the pre-release files
+    # git add the new release notes file
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = []
+exclude_patterns = ['upcoming_release_notes/template*']
 
 # The reST default role (used for this markup: `text`)
 default_role = 'any'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,3 +31,4 @@ provide relevant metadata based on the object type.
    :caption: Information
 
    releases.rst
+   upcoming_changes.rst

--- a/docs/source/upcoming_changes.rst
+++ b/docs/source/upcoming_changes.rst
@@ -1,0 +1,8 @@
+Upcoming Changes
+################
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   upcoming_release_notes/[0-9]*

--- a/docs/source/upcoming_release_notes/253-fix_tests.rst
+++ b/docs/source/upcoming_release_notes/253-fix_tests.rst
@@ -17,7 +17,7 @@ Maintenance
 -----------
 - Remove happi.device.Device from tests to avoid deprecation warnings
 - Add type annotations to test suite
-- Clean up fixture usage and separate `three_valves` fixture into `three_valves` and `client_with_three_valves`
+- Clean up fixture usage and separate ``three_valves`` fixture into ``three_valves`` and ``client_with_three_valves``
 - add pre-release notes scripts
 
 Contributors

--- a/docs/source/upcoming_release_notes/253-fix_tests.rst
+++ b/docs/source/upcoming_release_notes/253-fix_tests.rst
@@ -1,0 +1,22 @@
+253 fix_tests
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Remove happi.device.Device from tests to avoid deprecation warnings
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/253-fix_tests.rst
+++ b/docs/source/upcoming_release_notes/253-fix_tests.rst
@@ -17,8 +17,7 @@ Maintenance
 -----------
 - Remove happi.device.Device from tests to avoid deprecation warnings
 - Add type annotations to test suite
-- Clean up fixture usage and separate `three_valves` fixture into
-`three_valves` and `client_with_three_valves`
+- Clean up fixture usage and separate `three_valves` fixture into `three_valves` and `client_with_three_valves`
 - add pre-release notes scripts
 
 Contributors

--- a/docs/source/upcoming_release_notes/253-fix_tests.rst
+++ b/docs/source/upcoming_release_notes/253-fix_tests.rst
@@ -16,6 +16,10 @@ Bugfixes
 Maintenance
 -----------
 - Remove happi.device.Device from tests to avoid deprecation warnings
+- Add type annotations to test suite
+- Clean up fixture usage and separate `three_valves` fixture into
+`three_valves` and `client_with_three_valves`
+- add pre-release notes scripts
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/template-full.rst
+++ b/docs/source/upcoming_release_notes/template-full.rst
@@ -1,0 +1,36 @@
+IssueNumber Title
+#################
+
+Update the title above with your issue number and a 1-2 word title.
+Your filename should be issuenumber-title.rst, substituting appropriately.
+
+Make sure to fill out any section that represents changes you have made,
+or replace the default bullet point with N/A.
+
+API Changes
+-----------
+- List backwards-incompatible changes here.
+  Changes to PVs don't count as API changes for this library,
+  but changing method and component names or changing default behavior does.
+
+Features
+--------
+- List new updates that add utility to many classes,
+  provide a new base classes, add options to helper methods, etc.
+
+Bugfixes
+--------
+- List bug fixes that are not covered in the above sections.
+
+Maintenance
+-----------
+- List anything else. The intent is to accumulate changes
+  that the average user does not need to worry about.
+
+Contributors
+------------
+- List your github username and anyone else who made significant
+  code or conceptual contributions to the PR. You don't need to
+  add reviewers unless their suggestions lead to large rewrites.
+  These will be used in the release notes to give credit and to
+  notify you when your code is being tagged.

--- a/docs/source/upcoming_release_notes/template-short.rst
+++ b/docs/source/upcoming_release_notes/template-short.rst
@@ -1,0 +1,22 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import simplejson
+from click.testing import CliRunner
 
 from happi import Client, EntryInfo, HappiItem, OphydItem
 from happi.backends.json_db import JSONBackend
@@ -342,3 +343,8 @@ def three_valves(happi_client):
     for name, valve in valves.items():
         happi_client.backend.save(name, valve, insert=True)
     return valves
+
+
+@pytest.fixture(scope='function')
+def runner():
+    return CliRunner()

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -288,7 +288,7 @@ def mockqsbackend():
 
 
 @pytest.fixture(scope='function')
-def three_valves(happi_client):
+def three_valves():
     valve1 = {'name': 'valve1',
               'z': 300,
               'prefix': 'BASE:VGC1:PV',
@@ -331,18 +331,23 @@ def three_valves(happi_client):
               'kwargs': {'hi': 'oh hello'},
               }
 
-    for dev in happi_client.all_items:
-        happi_client.backend.delete(dev['_id'])
-
     valves = dict(
         VALVE1=valve1,
         VALVE2=valve2,
         VALVE3=valve3,
     )
 
-    for name, valve in valves.items():
-        happi_client.backend.save(name, valve, insert=True)
     return valves
+
+
+@pytest.fixture(scope='function')
+def client_with_three_valves(happi_client, three_valves):
+    for dev in happi_client.all_items:
+        happi_client.backend.delete(dev['_id'])
+
+    for name, valve in three_valves.items():
+        happi_client.backend.save(name, valve, insert=True)
+    return happi_client
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -186,7 +186,7 @@ def test_qsbackend_with_client(mockqsbackend):
 @requires_pcdsdevices
 def test_qsbackend_with_acromag(mockqsbackend):
     c = Client(database=mockqsbackend)
-    d = load_devices(*c.all_devices, pprint=False).__dict__
+    d = load_devices(*c.all_items, pprint=False).__dict__
     ai1 = d.get('ai_7')
     ao1 = d.get('ao_6')
     assert ai1.__class__.__name__ == 'EpicsSignalRO'

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -104,9 +104,11 @@ def test_json_find(valve_info, device_info, mockjson):
                for info in (device_info, valve_info))
 
 
-def test_find_regex(happi_client, three_valves):
+def test_find_regex(client_with_three_valves, three_valves):
+    client = client_with_three_valves
+
     def find(**kwargs):
-        return list(happi_client.backend.find_regex(kwargs))
+        return list(client.backend.find_regex(kwargs))
 
     valve1 = three_valves['VALVE1']
     valve2 = three_valves['VALVE2']

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import IPython
 import pytest
-from click.testing import CliRunner
 
 import happi
 from happi.cli import happi_cli, search
@@ -80,11 +79,6 @@ def db(tmp_path):
 }
 """)
     return str(json_path.absolute())
-
-
-@pytest.fixture(scope='function')
-def runner():
-    return CliRunner()
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -68,7 +68,7 @@ def test_create_device(happi_client, device_info):
 
 
 def test_all_devices(happi_client, device):
-    assert happi_client.all_devices == [device]
+    assert happi_client.all_items == [device]
 
 
 def test_add_device(happi_client, valve):
@@ -137,14 +137,14 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     res = happi_client.search(name=device_info['name'])
     # Single search return
     assert len(res) == 1
-    loaded_device = res[0].device
+    loaded_device = res[0].item
     assert loaded_device.prefix == device_info['prefix']
     assert loaded_device.name == device_info['name']
     # No results
     assert not happi_client.search(name='not')
     # Returned as dict
     res = happi_client.search(**device_info)
-    loaded_device = res[0].device
+    loaded_device = res[0].item
     assert loaded_device['prefix'] == device_info['prefix']
     assert loaded_device['name'] == device_info['name']
     # Search off keyword

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -178,22 +178,19 @@ def test_search_range(happi_client: Client, valve: OphydItem):
 
 
 def test_search_regex(
-    happi_client: Client,
-    three_valves: Dict[str, Dict[str, Any]]
+    client_with_three_valves: Client
 ):
+    client = client_with_three_valves
+
     def find(**kwargs):
         return [
             dict(item) for item in
-            happi_client.search_regex(**kwargs, flags=re.IGNORECASE)
+            client.search_regex(**kwargs, flags=re.IGNORECASE)
         ]
 
-    valve1 = dict(happi_client['VALVE1'])
-    valve2 = dict(happi_client['VALVE2'])
-    valve3 = dict(happi_client['VALVE3'])
-
-    assert valve1['name'] == three_valves['VALVE1']['name']
-    assert valve2['name'] == three_valves['VALVE2']['name']
-    assert valve3['name'] == three_valves['VALVE3']['name']
+    valve1 = dict(client['VALVE1'])
+    valve2 = dict(client['VALVE2'])
+    valve3 = dict(client['VALVE3'])
 
     assert find(beamline='LCLS') == [valve1, valve2, valve3]
     assert find(beamline='lcls') == [valve1, valve2, valve3]
@@ -317,19 +314,18 @@ def test_choices_for_field(happi_client: Client):
         happi_client.choices_for_field('not_a_field')
 
 
-def test_searchresults(
-    happi_client: Client, three_valves: Dict[str, Dict[str, Any]]
-):
-    valve1 = happi_client['VALVE1']
-    assert three_valves['VALVE1']['name'] == valve1.item.name
+def test_searchresults(client_with_three_valves: Client):
+    valve1 = client_with_three_valves['VALVE1']
     assert valve1.metadata == valve1
     assert isinstance(valve1.get(), types.SimpleNamespace)
 
 
 def test_client_mapping(
-    happi_client: Client, three_valves: Dict[str, Dict[str, Any]]
+    client_with_three_valves: Client,
+    three_valves: Dict[str, Dict[str, Any]]
 ):
-    assert len(happi_client) == 3
-    assert list(dict(happi_client)) == list(three_valves.keys())
-    for name in happi_client:
-        assert happi_client[name]['name']
+    client = client_with_three_valves
+    assert len(client) == 3
+    assert list(dict(client)) == list(three_valves.keys())
+    for name in client:
+        assert client[name]['name']

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -3,10 +3,11 @@ import os
 import re
 import tempfile
 import types
+from typing import Any, Dict
 
 import pytest
 
-from happi import Client, OphydItem
+from happi import Client, HappiItem, OphydItem
 from happi.backends.json_db import JSONBackend
 from happi.errors import DuplicateError, EntryError, SearchError, TransferError
 
@@ -21,7 +22,7 @@ def xdg_config_home(tmp_path):
 
 
 @pytest.fixture(scope='function')
-def happi_cfg(tmp_path, xdg_config_home):
+def happi_cfg(xdg_config_home):
     # Store current happi config
     xdg_cfg = os.environ.get("XDG_CONFIG_HOME", '')
     happi_cfg = os.environ.get("HAPPI_CFG", '')
@@ -43,7 +44,7 @@ path=db.json
     os.environ["XDG_CONFIG_HOME"] = xdg_cfg
 
 
-def test_find_document(happi_client, device_info):
+def test_find_document(happi_client: Client, device_info: Dict[str, Any]):
     doc = happi_client.find_document(**device_info)
     assert doc.pop('prefix') == device_info['prefix']
     assert doc.pop('name') == device_info['name']
@@ -58,7 +59,7 @@ def test_find_document(happi_client, device_info):
         doc = happi_client.find_document(prefix='Does not Exist')
 
 
-def test_create_device(happi_client, device_info):
+def test_create_device(happi_client: Client, device_info: Dict[str, Any]):
     device = happi_client.create_device(OphydItem, **device_info)
     assert device.prefix == device_info['prefix']
     assert device.name == device_info['name']
@@ -67,11 +68,11 @@ def test_create_device(happi_client, device_info):
         happi_client.create_device(int)
 
 
-def test_all_devices(happi_client, device):
+def test_all_devices(happi_client: Client, device: OphydItem):
     assert happi_client.all_items == [device]
 
 
-def test_add_device(happi_client, valve):
+def test_add_device(happi_client: Client, valve: OphydItem):
     happi_client.add_device(valve)
     # No duplicates
     with pytest.raises(DuplicateError):
@@ -82,14 +83,18 @@ def test_add_device(happi_client, valve):
         happi_client.add_device(d)
 
 
-def test_add_and_find_device(happi_client, valve, valve_info):
+def test_add_and_find_device(
+    happi_client: Client,
+    valve: OphydItem,
+    valve_info: Dict[str, Any]
+):
     happi_client.add_device(valve)
     loaded_device = happi_client.find_device(**valve_info)
     assert loaded_device.prefix == valve.prefix
     assert loaded_device.name == valve.name
 
 
-def test_find_device(happi_client, device_info):
+def test_find_device(happi_client: Client, device_info: Dict[str, Any]):
     device = happi_client.find_device(**device_info)
     assert isinstance(device, OphydItem)
     assert device.prefix == device_info['prefix']
@@ -107,7 +112,7 @@ def test_find_device(happi_client, device_info):
         happi_client.find_device(**bad)
 
 
-def test_change_item_name(happi_client, device_info):
+def test_change_item_name(happi_client: Client, device_info: Dict[str, Any]):
     device = happi_client.find_device(**device_info)
     assert device.name != 'new_name'
     device.name = 'new_name'
@@ -123,7 +128,7 @@ def test_change_item_name(happi_client, device_info):
     assert happi_client.all_items == [new_device]
 
 
-def test_validate(happi_client):
+def test_validate(happi_client: Client):
     # No bad devices
     assert happi_client.validate() == list()
     # A single bad device
@@ -132,7 +137,11 @@ def test_validate(happi_client):
     assert happi_client.validate() == ['bad']
 
 
-def test_search(happi_client, device, valve, device_info, valve_info):
+def test_search(
+    happi_client: Client,
+    valve: OphydItem,
+    device_info: Dict[str, Any]
+):
     happi_client.add_device(valve)
     res = happi_client.search(name=device_info['name'])
     # Single search return
@@ -152,7 +161,7 @@ def test_search(happi_client, device, valve, device_info, valve_info):
     assert len(res) == 2
 
 
-def test_search_range(happi_client, device, valve, device_info, valve_info):
+def test_search_range(happi_client: Client, valve: OphydItem):
     happi_client.add_device(valve)
     # Search between two points
     res = happi_client.search_range('z', start=0, end=500)
@@ -168,7 +177,10 @@ def test_search_range(happi_client, device, valve, device_info, valve_info):
         happi_client.search_range('z', start=1000, end=5)
 
 
-def test_search_regex(happi_client, three_valves):
+def test_search_regex(
+    happi_client: Client,
+    three_valves: Dict[str, Dict[str, Any]]
+):
     def find(**kwargs):
         return [
             dict(item) for item in
@@ -179,6 +191,10 @@ def test_search_regex(happi_client, three_valves):
     valve2 = dict(happi_client['VALVE2'])
     valve3 = dict(happi_client['VALVE3'])
 
+    assert valve1['name'] == three_valves['VALVE1']['name']
+    assert valve2['name'] == three_valves['VALVE2']['name']
+    assert valve3['name'] == three_valves['VALVE3']['name']
+
     assert find(beamline='LCLS') == [valve1, valve2, valve3]
     assert find(beamline='lcls') == [valve1, valve2, valve3]
     assert find(beamline='nomatch') == []
@@ -187,14 +203,23 @@ def test_search_regex(happi_client, three_valves):
     assert find(prefix='BASE:VGC[23]:PV') == [valve2, valve3]
 
 
-def test_get_by_id(happi_client, device, valve, device_info, valve_info):
+def test_get_by_id(
+    happi_client: Client,
+    valve: OphydItem,
+    valve_info: Dict[str, Any]
+):
     happi_client.add_device(valve)
     name = valve_info['name']
     for k, v in valve_info.items():
         assert happi_client[name][k] == valve_info[k]
 
 
-def test_remove_device(happi_client, device, valve, device_info):
+def test_remove_device(
+    happi_client: Client,
+    device: OphydItem,
+    valve: OphydItem,
+    device_info: Dict[str, Any]
+):
     happi_client.remove_device(device)
     assert list(happi_client.backend.find(device_info)) == []
     # Invalid Device
@@ -205,7 +230,7 @@ def test_remove_device(happi_client, device, valve, device_info):
         happi_client.remove_device(valve)
 
 
-def test_export(happi_client, valve):
+def test_export(happi_client: Client, valve: OphydItem):
     # Setup client with both devices
     happi_client.add_device(valve)
     fd, temp_path = tempfile.mkstemp()
@@ -220,7 +245,7 @@ def test_export(happi_client, valve):
     os.close(fd)
 
 
-def test_load_device(happi_client, device):
+def test_load_device(happi_client: Client, device: OphydItem):
     device = happi_client.load_device(name=device.name)
     assert isinstance(device, types.SimpleNamespace)
     assert device.hi == 'oh hello'
@@ -234,14 +259,19 @@ def test_load_device(happi_client, device):
         ('valve', 'Item1')
     ],
 )
-def test_change_container_fail(happi_client, item, target, request):
+def test_change_container_fail(
+    happi_client: Client,
+    item: str,
+    target: str,
+    request: pytest.FixtureRequest
+):
     i = request.getfixturevalue(item)
     t = request.getfixturevalue(target)
     with pytest.raises(TransferError):
         happi_client.change_container(i, t)
 
 
-def test_change_fail_mandatory(happi_client, item2_dev):
+def test_change_fail_mandatory(happi_client: Client, item2_dev: HappiItem):
     with pytest.raises(TransferError):
         happi_client.change_container(item2_dev, OphydItem)
 
@@ -249,7 +279,12 @@ def test_change_fail_mandatory(happi_client, item2_dev):
 @pytest.mark.parametrize(
     'item, target', [('item1_dev', 'Item1'), ('item2_dev', 'Item2')],
 )
-def test_change_container_pass(happi_client, item, target, request):
+def test_change_container_pass(
+    happi_client: Client,
+    item: str,
+    target: str,
+    request: pytest.FixtureRequest
+):
     i = request.getfixturevalue(item)
     t = request.getfixturevalue(target)
     kw = happi_client.change_container(i, t)
@@ -258,7 +293,7 @@ def test_change_container_pass(happi_client, item, target, request):
         assert i.post()[k] == kw[k]
 
 
-def test_find_cfg(happi_cfg):
+def test_find_cfg(happi_cfg: str):
     # Use our config directory
     assert happi_cfg == Client.find_config()
     # Set the path explicitly using HAPPI env variable
@@ -266,13 +301,14 @@ def test_find_cfg(happi_cfg):
     assert happi_cfg == Client.find_config()
 
 
-def test_from_cfg(happi_cfg):
+def test_from_cfg(happi_cfg: str):
+    # happi_cfg modifies environment variables to make config discoverable
     client = Client.from_config()
     assert isinstance(client.backend, JSONBackend)
     assert client.backend.path == 'db.json'
 
 
-def test_choices_for_field(happi_client):
+def test_choices_for_field(happi_client: Client):
     name_choices = happi_client.choices_for_field('name')
     assert name_choices == {'alias'}
     prefix_choices = happi_client.choices_for_field('prefix')
@@ -281,16 +317,19 @@ def test_choices_for_field(happi_client):
         happi_client.choices_for_field('not_a_field')
 
 
-def test_searchresults(happi_client, three_valves):
+def test_searchresults(
+    happi_client: Client, three_valves: Dict[str, Dict[str, Any]]
+):
     valve1 = happi_client['VALVE1']
-    print(repr(valve1))
-    print(dict(valve1))
+    assert three_valves['VALVE1']['name'] == valve1.item.name
     assert valve1.metadata == valve1
     assert isinstance(valve1.get(), types.SimpleNamespace)
 
 
-def test_client_mapping(happi_client, three_valves):
+def test_client_mapping(
+    happi_client: Client, three_valves: Dict[str, Dict[str, Any]]
+):
     assert len(happi_client) == 3
-    assert list(dict(happi_client)) == ['VALVE1', 'VALVE2', 'VALVE3']
+    assert list(dict(happi_client)) == list(three_valves.keys())
     for name in happi_client:
         assert happi_client[name]['name']

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-from happi import Device
+from happi import HappiItem
 from happi.device import EntryInfo
 from happi.errors import ContainerError
 
@@ -20,7 +20,7 @@ def test_init(device, device_info):
 
 def test_list_enforce():
     # Generic device with a list enforce
-    class MyDevice(Device):
+    class MyDevice(HappiItem):
         list_attr = EntryInfo(enforce=['a', 'b', 'c'],
                               enforce_doc='list only')
 
@@ -37,7 +37,7 @@ def test_list_enforce():
 
 
 def test_regex_enforce():
-    class MyDevice(Device):
+    class MyDevice(HappiItem):
         re_attr = EntryInfo(enforce=re.compile(r'[A-Z]{2}$'),
                             enforce_doc='only 2 chars')
 
@@ -88,7 +88,7 @@ def test_enforce(device):
 
 def test_container_error():
     with pytest.raises(ContainerError):
-        class MyDevice(Device):
+        class MyDevice(HappiItem):
             fault = EntryInfo(enforce=int,  default='not-int')
 
 
@@ -99,7 +99,7 @@ def test_mandatory_info(device):
 
 def test_restricted_attr():
     with pytest.raises(TypeError):
-        class MyDevice(Device):
+        class MyDevice(HappiItem):
             info_names = EntryInfo()
 
 
@@ -120,26 +120,26 @@ def test_show_info(device, device_info):
 
 
 def test_device_equivalance():
-    a = Device(name='abcd', prefix='b')
-    b = Device(name='abcd', prefix='b')
-    c = Device(name='cbcd', prefix='b')
+    a = HappiItem(name='abcd', prefix='b')
+    b = HappiItem(name='abcd', prefix='b')
+    c = HappiItem(name='cbcd', prefix='b')
     assert a == b
     assert not c == a
 
 
 def test_dictify():
-    a = Device(name='abcd', prefix='b')
+    a = HappiItem(name='abcd', prefix='b')
     assert dict(a) == a.post()
 
 
 def test_device_copy():
-    a = Device(name='abcd', prefix='b')
+    a = HappiItem(name='abcd', prefix='b')
     b = copy.copy(a)
     assert dict(a) == dict(b)
 
 
 def test_device_deepcopy():
-    a = Device(name='abcd', prefix='abc', kwargs={'abc': 'def'})
+    a = HappiItem(name='abcd', prefix='abc', kwargs={'abc': 'def'})
 
     c = copy.deepcopy(a)
     assert a.kwargs == c.kwargs

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -1,7 +1,7 @@
 import copy
 import io
 import re
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Type
 
 import pytest
 
@@ -58,11 +58,7 @@ def test_regex_enforce():
                           (str, 'hat', 'hat'), (str, 5, '5'),
                           (bool, True, True), (bool, 0, False),
                           (bool, 'true', True), (bool, 'NO', False)])
-def test_type_enforce_ok(
-    type_spec: Tuple[type, Any, Any],
-    value: Tuple[type, Any, Any],
-    expected: Tuple[type, Any, Any]
-):
+def test_type_enforce_ok(type_spec: Type, value: Any, expected: Any):
     entry = EntryInfo(enforce=type_spec)
     assert entry.enforce_value(value) == expected
 
@@ -70,10 +66,7 @@ def test_type_enforce_ok(
 @pytest.mark.parametrize('type_spec, value',
                          [(int, 'cats'),
                           (bool, '24'), (bool, 'catastrophe')])
-def test_type_enforce_exceptions(
-    type_spec: Tuple[type, Any, Any],
-    value: Tuple[type, Any, Any]
-):
+def test_type_enforce_exceptions(type_spec: Type, value: Any):
     entry = EntryInfo(enforce=type_spec, enforce_doc='bad type')
     with pytest.raises(ValueError) as excinfo:
         entry.enforce_value(value)

--- a/happi/tests/test_device.py
+++ b/happi/tests/test_device.py
@@ -152,4 +152,4 @@ def test_add_and_save(three_valves, device, happi_client):
     device.active = False
     device.save()
 
-    assert not happi_client[device.name].device.active
+    assert not happi_client[device.name].item.active

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from happi import EntryInfo, OphydItem, cache
@@ -10,7 +12,7 @@ class TimeDevice(OphydItem):
     days = EntryInfo("Number of days", enforce=int)
 
 
-def test_fill_template(device):
+def test_fill_template(device: OphydItem):
     # Check that we can properly render a template
     template = "{{name}}"
     assert device.name == fill_template(template, device)
@@ -92,7 +94,7 @@ def test_add_md():
         pytest.param(True, id="load_times")
     ],
 )
-def test_load_devices(threaded: bool, post_load, include_load_time: bool):
+def test_load_devices(threaded: bool, post_load: Any, include_load_time: bool):
     # Create a bunch of devices to load
     devs = [TimeDevice(name='test_1', prefix='Tst1:This', beamline='TST',
                        device_class='datetime.timedelta', args=list(), days=10,

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -1,11 +1,12 @@
 import pytest
 
-from happi import Device, EntryInfo, cache
+from happi import EntryInfo, OphydItem, cache
+from happi.item import HappiItem
 from happi.loader import fill_template, from_container, load_devices
 from happi.utils import create_alias
 
 
-class TimeDevice(Device):
+class TimeDevice(OphydItem):
     days = EntryInfo("Number of days", enforce=int)
 
 
@@ -62,11 +63,11 @@ def test_caching():
 
 
 def test_add_md():
-    d = Device(name='test', prefix='Tst:This:3',
-               beamline="TST", args=list(),
-               device_class="happi.Device")
+    d = HappiItem(name='test', prefix='Tst:This:3',
+                  beamline="TST", args=list(),
+                  device_class="happi.HappiItem")
     obj = from_container(d, attach_md=True)
-    assert obj.md.beamline == 'TST'
+    assert obj.md.extraneous['beamline'] == 'TST'
     assert obj.md.name == 'test'
 
 
@@ -102,8 +103,8 @@ def test_load_devices(threaded: bool, post_load, include_load_time: bool):
             TimeDevice(name='test_3', prefix='Tst3:This', beamline='TST',
                        device_class='datetime.timedelta', args=list(), days=10,
                        kwargs={'days': '{{days}}', 'seconds': 30}),
-            Device(name='bad', prefix='Not:Here', beamline='BAD',
-                   device_class='non.existant')]
+            HappiItem(name='bad', prefix='Not:Here', beamline='BAD',
+                      device_class='non.existant')]
     # Load our devices
     space = load_devices(
         *devs,

--- a/happi/tests/test_prompt.py
+++ b/happi/tests/test_prompt.py
@@ -1,0 +1,40 @@
+import pytest
+
+from happi.prompt import enforce_list, read_user_dict
+
+
+def test_user_dict(runner):
+    default_dict = {'default_key': 'default_value'}
+
+    # normal operation
+    with runner.isolation('key1\nvalue1'):
+        result = read_user_dict('prompt', default=default_dict)
+
+    assert result == {'key1': 'value1'}
+
+    # read default
+    with runner.isolation('\n'):
+        result = read_user_dict('prompt', default=default_dict)
+
+    assert result == default_dict
+
+    # reject keywords
+    with runner.isolation('is\nnotis\n1\n'):
+        result = read_user_dict('prompt', default=default_dict)
+
+    assert result == {'notis': 1}
+
+    # replace values
+    with runner.isolation('key\n1\nkey\n2'):
+        result = read_user_dict('prompt', default=default_dict)
+
+    assert result == {'key': 2}
+
+
+@pytest.mark.parametrize('user_in', (
+    ['a', 'b', 2, 3],
+    "['a', 'b', 2, 3]"
+))
+def test_enforce_list(user_in):
+    result = enforce_list(user_in)
+    assert result == ['a', 'b', 2, 3]

--- a/happi/tests/test_prompt.py
+++ b/happi/tests/test_prompt.py
@@ -1,6 +1,7 @@
 import pytest
 
 from happi.prompt import enforce_list, read_user_dict
+from happi.utils import EnforceError
 
 
 def test_user_dict(runner):
@@ -38,3 +39,13 @@ def test_user_dict(runner):
 def test_enforce_list(user_in):
     result = enforce_list(user_in)
     assert result == ['a', 'b', 2, 3]
+
+
+@pytest.mark.parametrize('user_in', (
+    'a',
+    "['a', 'b'=2, 2, 3]",
+    '[1,2,3,4.5.4]'
+))
+def test_enforce_list_fail(user_in: str):
+    with pytest.raises(EnforceError):
+        _ = enforce_list(user_in)

--- a/happi/tests/test_prompt.py
+++ b/happi/tests/test_prompt.py
@@ -1,10 +1,13 @@
+from typing import Any
+
 import pytest
+from click.testing import CliRunner
 
 from happi.prompt import enforce_list, read_user_dict
 from happi.utils import EnforceError
 
 
-def test_user_dict(runner):
+def test_user_dict(runner: CliRunner):
     default_dict = {'default_key': 'default_value'}
 
     # normal operation
@@ -36,7 +39,7 @@ def test_user_dict(runner):
     ['a', 'b', 2, 3],
     "['a', 'b', 2, 3]"
 ))
-def test_enforce_list(user_in):
+def test_enforce_list(user_in: Any):
     result = enforce_list(user_in)
     assert result == ['a', 'b', 2, 3]
 


### PR DESCRIPTION
## Description
- Fixes deprecation warnings for `happi.device.Device`.  Remaining warnings are from other libraries (pcdsdevices defines containers with `happi.device.Device`, other unrelated warnings)
- Type annotations for test fixtures
- Split `three_valve` fixture into `three_valve` (containing valve info) and `client_with_three_valves` to avoid confusion over fixture side effects
- add pre-release notes templates

## Motivation and Context
#253 , and I was tired of seeing the same warnings.  I reworked a bunch of cli tests in the search-refactor PR as well

## How Has This Been Tested?
We test the tests via local pytest and automated ci tests

## Where Has This Been Documented?
this PR

old:
![old](https://user-images.githubusercontent.com/35379409/171947390-0893c533-f468-4d77-b1a8-f1894e4b390e.png)
new:
![new](https://user-images.githubusercontent.com/35379409/171947544-4b35817f-935f-4b65-90d5-32ef42179442.png)
