### PR TITLE
BUG: allow `happi search` to match int numerics

### DIFF
--- a/docs/source/upcoming_release_notes/261-search_nums.rst
+++ b/docs/source/upcoming_release_notes/261-search_nums.rst
@@ -1,0 +1,22 @@
+261 search_nums
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Allow int search values to match their float counterparts
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -132,8 +132,16 @@ def search(
             continue
 
         elif is_number(value):
-            logger.debug('Changed %s to float', value)
-            # value = str(float(value))
+            if float(value) == int(float(value)):
+                # value is an int, allow the float version (optional .0)
+                logger.debug(f'looking for int value: {value}')
+                value = f'^{int(float(value))}(\\.0+$)?$'
+
+                # don't translate from glob
+                client_args[criteria] = value
+                continue
+            else:
+                value = str(float(value))
         else:
             logger.debug('Value %s interpreted as string', value)
 

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -219,6 +219,29 @@ def test_search_z_range(
     assert 'No devices found' in conflict_result.output
 
 
+def test_search_int_float(runner: CliRunner, happi_cfg: str):
+    int_result = runner.invoke(happi_cli, ['--path', happi_cfg,
+                               'search', '--names', 'z=3'])
+    float_result = runner.invoke(happi_cli, ['--path', happi_cfg,
+                                 'search', '--names', 'z=3.0'])
+    assert int_result.output == float_result.output
+
+    # # TODO: add this test case once edit works on extraneous info
+    # edit_result = runner.invoke(
+    #     happi_cli,
+    #     ['-v', '--path', happi_cfg, 'edit', 'tst_base_pim', 'z=3.001'],
+    #     input='y'
+    # )
+    # assert edit_result.exit_code == 0
+
+    # int_result = runner.invoke(happi_cli, ['--path', happi_cfg,
+    #                            'search', '--names', 'z=3'])
+    # float_result = runner.invoke(happi_cli, ['--path', happi_cfg,
+    #                              'search', '--names', 'z=3.0'])
+    # assert int_result.output == ''
+    # assert float_result.output == ''
+
+
 def test_both_range_and_regex_search(client: happi.client.Client):
     # we're only interested in getting this entry (TST_BASE_PIM2)
     res = client.search_regex(z='6.0')


### PR DESCRIPTION
## Description
- If search term is an int, generates regex that also matches its float counterpart

## Motivation and Context
closes #256 

In building tests I realized `happi edit` does not allow editing of `extraneous` information.  A portion of the new test has been commented out for when that is fixed.  (see #262)

## How Has This Been Tested?
Test suite, interactively

## Where Has This Been Documented?
This PR

![image](https://user-images.githubusercontent.com/35379409/172715707-9428c841-b97b-4dd2-a62b-e2d2ea11c5bd.png)