### PR TITLE
ENH: Benchmark, Profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Terminal text editors
+*.swp
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ env:
 
     # Extra dependencies needed to run the tests which are not included
     # at the recipe and dev-requirements.txt. E.g. PyQt
-    - CONDA_EXTRAS=""
+    - CONDA_EXTRAS="pcdsdevices pcdsutils line_profiler"
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip
-    - PIP_EXTRAS=""
+    - PIP_EXTRAS="pcdsdevices pcdsutils line-profiler"
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -749,6 +749,9 @@ def profile(
         for parent_class in parents:
             module = parent_class.__module__
             module_names.add(module.split('.')[0])
+    # All all ophyd control layers
+    module_names.add('epics')
+    module_names.add('caproto')
 
     # Profile stage 3: create the device classes
     logger.info('Creating the device classes')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -610,9 +610,14 @@ class Stats:
                 logger.warning(
                     f'{result["name"]} does not have wait_for_connection.'
                 )
-            except Exception:
+            except TimeoutError:
                 logger.warning(
                     'Timeout after 10s while waiting for connection of '
+                    f'{result["name"]}',
+                )
+            except Exception:
+                logger.warning(
+                    'Unknown exception while waiting for connection of '
                     f'{result["name"]}',
                 )
         return time.monotonic() - start

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -450,8 +450,7 @@ benchmark_sort_keys = [
               help=(
                 "Sort the output table. Valid options are "
                 f"{', '.join(benchmark_sort_keys)}"
-              )
-            )
+              ))
 @click.option('--glob/--regex', 'use_glob', default=True,
               help='Use glob style (default) or regex style search terms. '
               r'Regex requires backslashes to be escaped (eg. at\\d.\\d)')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -527,6 +527,9 @@ def benchmark(
 
 @dataclasses.dataclass
 class Stats:
+    """
+    Collect and hold results from benchmark runs.
+    """
     name: str
     avg_time: float
     iterations: int
@@ -542,6 +545,9 @@ class Stats:
         iterations: int,
         wait_connected: bool,
     ) -> Stats:
+        """
+        Create an object using a search result and store benchmarking info.
+        """
         logger.debug(f'Checking stats for {result["name"]}')
         if not duration and not iterations:
             return Stats(
@@ -578,6 +584,9 @@ class Stats:
 
     @staticmethod
     def import_benchmark(result: happi.SearchResult) -> float:
+        """
+        Check only the module import in isolation.
+        """
         start = time.monotonic()
         happi.loader.import_class(result.item.device_class)
         return time.monotonic() - start
@@ -587,6 +596,9 @@ class Stats:
         result: happi.SearchResult,
         wait_connected: bool,
     ) -> float:
+        """
+        Create one object and time it.
+        """
         start = time.monotonic()
         device = result.get(use_cache=False)
         if wait_connected:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -522,7 +522,9 @@ def benchmark(
         reverse=True,
     ):
         table.add_row([getattr(stats, key) for key in benchmark_sort_keys])
+    print('Benchmark output:')
     print(table)
+    print('Benchmark completed successfully')
 
 
 @dataclasses.dataclass

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -456,6 +456,7 @@ def benchmark(
         'iterations',
         'tot_time',
         'max_time',
+        'import_time',
     ]
     if sort_key not in table.field_names:
         logger.warning(f'Sort key {sort_key} invalid, reverting to avg_time')
@@ -472,6 +473,7 @@ def benchmark(
                 stats.iterations,
                 stats.tot_time,
                 stats.max_time,
+                stats.import_time,
             ]
         )
     print(table)
@@ -484,6 +486,7 @@ class Stats:
     iterations: int
     tot_time: float
     max_time: float
+    import_time: float
 
     @classmethod
     def from_search_result(
@@ -497,6 +500,7 @@ class Stats:
         if not duration and not iterations:
             return Stats(avg_time=0, iterations=0, tot_time=0)
         raw_stats: List[float] = []
+        import_time = cls.import_benchmark(result)
         if iterations > 0:
             for _ in range(iterations):
                 raw_stats.append(cls.run_one_benchmark(
@@ -516,7 +520,14 @@ class Stats:
             iterations=len(raw_stats),
             tot_time=sum(raw_stats),
             max_time=max(raw_stats),
+            import_time=import_time,
         )
+
+    @staticmethod
+    def import_benchmark(result: happi.SearchResult) -> float:
+        start = time.monotonic()
+        happi.loader.import_class(result.item.device_class)
+        return time.monotonic() - start
 
     @staticmethod
     def run_one_benchmark(

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -784,9 +784,10 @@ def profile(
         for parent_class in parents:
             module = parent_class.__module__
             module_names.add(module.split('.')[0])
-    # All all ophyd control layers
-    module_names.add('epics')
-    module_names.add('caproto')
+    # Add imported ophyd control layers
+    for cl in ('epics', 'caproto'):
+        if cl in sys.modules:
+            module_names.add(cl)
 
     # Profile stage 3: create the device classes
     logger.info('Creating the device classes')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -401,11 +401,13 @@ def transfer(ctx, name: str, target: str):
 @click.option("-d", "--duration", type=float, default=0)
 @click.option("-i", "--iterations", type=int, default=0)
 @click.option("-w", "--wait-connected", type=bool, default=False)
+@click.option("-t", "--tracebacks", type=bool, default=False)
 def benchmark(
     ctx,
     duration: float,
     iterations: int,
     wait_connected: bool,
+    tracebacks: bool,
 ):
     """
     Check which happi devices have the longest startup times.
@@ -430,6 +432,7 @@ def benchmark(
     items = client.search()
     logger.info(f'Done, took {time.monotonic() - start} s')
     for result in items:
+        logger.info(f'Running benchmark on {result["name"]}')
         try:
             stats = Stats.from_search_result(
                 result=result,
@@ -438,7 +441,10 @@ def benchmark(
                 wait_connected=wait_connected,
             )
         except Exception:
-            logger.exception(f'Error running benchmark for {result["name"]}')
+            logger.error(
+                f'Error running benchmark on {result["name"]}',
+                exc_info=tracebacks,
+            )
         else:
             full_stats.append(stats)
     table = prettytable.PrettyTable()

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -708,6 +708,7 @@ def profile(
             print_results()
         elif profiler == 'cprofile':
             context_profiler.print_stats(sort='cumulative')
+        print('Profile completed successfully')
 
     # Profile stage 1: searching the happi database
     logger.info('Searching the happi database')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -65,6 +65,11 @@ def happi_cli(ctx, path, verbose):
     # through to new context objects
     ctx.obj = client
 
+    # Cleanup tasks related to loaded devices
+    @ctx.call_on_close
+    def device_cleanup():
+        ophyd_cleanup()
+
 
 @happi_cli.command()
 @click.option('--show_json', '-j', is_flag=True,
@@ -812,6 +817,15 @@ def profile(
         f'Created the device classes in {time.monotonic() - start} s'
     )
     return output_profile()
+
+
+def ophyd_cleanup():
+    """Clean up ophyd - avoid teardown errors by stopping callbacks."""
+    if 'ophyd' in sys.modules:
+        import ophyd
+        dispatcher = ophyd.cl.get_dispatcher()
+        if dispatcher is not None:
+            dispatcher.stop()
 
 
 def main():

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -763,7 +763,12 @@ def profile(
         output_now=False,
     ):
         for search_result in items:
-            search_result.get(use_cache=False)
+            try:
+                search_result.get(use_cache=False)
+            except Exception:
+                logger.warning(
+                    f'Failed to create {search_result["name"]}'
+                )
     logger.info(
         f'Created the device classes in {time.monotonic() - start} s'
     )

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import tempfile
 from unittest.mock import patch
 
@@ -49,6 +50,9 @@ except ImportError as exc:
 
 requires_pcdsdevices = pytest.mark.skipif(not has_pcdsdevices,
                                           reason='Missing pcdsdevices')
+
+
+requires_py39 = pytest.mark.skipif(sys.version_info < (3, 9))
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -52,7 +52,10 @@ requires_pcdsdevices = pytest.mark.skipif(not has_pcdsdevices,
                                           reason='Missing pcdsdevices')
 
 
-requires_py39 = pytest.mark.skipif(sys.version_info < (3, 9))
+requires_py39 = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason='Optional dependency needs at least py39',
+)
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -11,7 +11,7 @@ from happi.backends.json_db import JSONBackend
 from happi.errors import DuplicateError, SearchError
 from happi.loader import load_devices
 
-from .conftest import (requires_mongo, requires_pcdsdevices,
+from .conftest import (requires_mongo, requires_pcdsdevices, requires_py39,
                        requires_questionnaire)
 
 
@@ -186,6 +186,7 @@ def test_qsbackend_with_client(mockqsbackend):
 
 @requires_questionnaire
 @requires_pcdsdevices
+@requires_py39
 def test_qsbackend_with_acromag(mockqsbackend):
     c = Client(database=mockqsbackend)
     d = load_devices(*c.all_items, pprint=False).__dict__
@@ -197,6 +198,7 @@ def test_qsbackend_with_acromag(mockqsbackend):
 
 @requires_questionnaire
 @requires_pcdsdevices
+@requires_py39
 def test_beckoff_axis_device_class(mockqsbackend):
     c = Client(database=mockqsbackend)
     d = load_devices(*c.all_items).__dict__

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -1,5 +1,7 @@
 # test_cli.py
 
+import functools
+import itertools
 import logging
 import re
 from typing import Any, Iterable, List, Tuple
@@ -13,6 +15,9 @@ from click.testing import CliRunner
 import happi
 from happi.cli import happi_cli, search
 from happi.errors import SearchError
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
@@ -114,12 +119,24 @@ def assert_match_expected(
     expected_output: Iterable[str]
 ):
     """standard checks for a cli result, confirms output matches expected"""
+    logger.debug(result.output)
     assert result.exit_code == 0
     assert not result.exception
 
     trimmed_output = trim_split_output(result.output)
     for message, expected in zip(trimmed_output, expected_output):
         assert message == expected
+
+
+def assert_in_expected(
+    result: click.testing.Result,
+    expected_inclusion: str
+):
+    """standard checks for a cli result, confirms output includes expected"""
+    logger.debug(result.output)
+    assert result.exit_code == 0
+    assert not result.exception
+    assert expected_inclusion in result.output
 
 
 def test_cli_no_argument(runner: CliRunner):
@@ -618,3 +635,38 @@ def test_transfer_cli(
     results = runner.invoke(happi_cli, ['--path', happi_cfg, 'transfer',
                             'tst_base_pim', 'OphydItem'], input=from_user)
     assert_match_expected(results, expected_output)
+
+
+def arg_variants(variants: Tuple[Tuple[Tuple[str]]]):
+    """
+    Collapse argument variants into all possible combinations.
+    """
+    for arg_set in itertools.product(*variants):
+        yield functools.reduce(
+            lambda x, y: x+y,
+            arg_set,
+            )
+
+
+benchmark_arg_variants = (
+    (('--duration', '0.1'), ('--iterations', '5')),
+    (('--wait-connected',), ()),
+    (('--tracebacks',), ()),
+    (('--sort-key', 'name'), ()),
+    (('--glob', '*pim'), ('--regex', '.*pim'), ()),
+)
+
+
+@pytest.mark.parametrize(
+    "args", tuple(arg_variants(benchmark_arg_variants))
+)
+def test_benchmark_cli(runner: CliRunner, happi_cfg: str, args: Tuple[str]):
+    # Make sure the benchmark can complete in some form with valid inputs
+    result = runner.invoke(
+        happi_cli,
+        ['--path', happi_cfg, 'benchmark'] + list(args),
+    )
+    assert_in_expected(
+        result,
+        'Benchmark completed successfully'
+    )

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -16,6 +16,15 @@ import happi
 from happi.cli import happi_cli, search
 from happi.errors import SearchError
 
+try:
+    import pcdsutils.profile
+    if pcdsutils.profile.has_line_profiler:
+        test_line_prof = True
+    else:
+        test_line_prof = False
+except ImportError:
+    test_line_prof = False
+
 
 logger = logging.getLogger(__name__)
 
@@ -685,6 +694,8 @@ profile_arg_variants = (
 )
 def test_profile_cli(runner: CliRunner, happi_cfg: str, args: Tuple[str]):
     # Make sure the profile can complete in some form with valid inputs
+    if 'pcdsutils' in args and not test_line_prof:
+        pytest.skip('Missing pcdsutils or line_profiler.')
     result = runner.invoke(
         happi_cli,
         ['--path', happi_cfg, 'profile'] + list(args),

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -670,3 +670,26 @@ def test_benchmark_cli(runner: CliRunner, happi_cfg: str, args: Tuple[str]):
         result,
         'Benchmark completed successfully'
     )
+
+
+profile_arg_variants = (
+    (('--database',), ('--import',), ('--object', ),
+     ('--all', ), ('--import', '--object')),
+    (('--profiler', 'pcdsutils'), ('--profiler', 'cprofile'), ()),
+    (('--glob', '*pim'), ('--regex', '.*pim'), ()),
+)
+
+
+@pytest.mark.parametrize(
+    "args", tuple(arg_variants(profile_arg_variants))
+)
+def test_profile_cli(runner: CliRunner, happi_cfg: str, args: Tuple[str]):
+    # Make sure the profile can complete in some form with valid inputs
+    result = runner.invoke(
+        happi_cli,
+        ['--path', happi_cfg, 'profile'] + list(args),
+    )
+    assert_in_expected(
+        result,
+        'Profile completed successfully'
+    )

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import logging
 import sys
 
 import pytest
@@ -14,4 +15,5 @@ if __name__ == '__main__':
 
     print('pytest arguments: {}'.format(args))
 
+    logging.basicConfig(level=logging.DEBUG)
     sys.exit(pytest.main(args))

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import logging
 import sys
 
 import pytest
@@ -15,5 +14,4 @@ if __name__ == '__main__':
 
     print('pytest arguments: {}'.format(args))
 
-    logging.basicConfig(level=logging.DEBUG)
     sys.exit(pytest.main(args))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- [x] Refactor CLI slightly to allow us to re-use searching logic
- [x] Add `happi benchmark` for identifying which beamline devices are slow to load
- [x] Add `happi profile` for identifying why particular beamline devices are slow to load

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm on a quest to improve the loading performance of our specific ophyd devices at LCLS. I want to build these tools into `happi` so that it becomes easy to identify when an arbitrary device is taking a long time to load.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively + some basic argument tests to make sure the benchmark and profile can at least complete.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
