### PR TITLE
REF/PERF: caching mechanism for happi Client and backend databases

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = .git,__pycache__,build,dist,versioneer.py,happi/_version.py,docs/source/conf.py
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203, E501

--- a/docs/release_notes.py
+++ b/docs/release_notes.py
@@ -14,6 +14,7 @@ TITLE_UNDER = '#'
 RELEASE_UNDER = '='
 SECTION_UNDER = '-'
 
+
 def parse_pre_release_file(path):
     """
     Return dict mapping of release notes section to lines.

--- a/docs/source/upcoming_release_notes/235-performance.rst
+++ b/docs/source/upcoming_release_notes/235-performance.rst
@@ -1,0 +1,26 @@
+235 client performance
+######################
+
+API Changes
+-----------
+- Added ``happi.Client.retain_cache_context`` for clients that desire to
+  control when reloading the database from a happi backend happens.
+- Backend implementations may now optionally support a caching mechanism with
+  ``clear_cache`` being called externally by the client when desirable.
+
+Features
+--------
+- Significant performance increase for JSON-backed happi clients.
+
+Bugfixes
+--------
+- Issue where happi Client would repeatedly (and unnecessarily) make database
+  backend calls has been fixed.
+
+Maintenance
+-----------
+- Added relaxed flake8 configuration.
+
+Contributors
+------------
+- klauer

--- a/happi/backends/core.py
+++ b/happi/backends/core.py
@@ -7,12 +7,24 @@ logger = logging.getLogger(__name__)
 
 
 class _Backend:
-    """Base class for backend database."""
+    """
+    Base class for backend database.
+
+    Backends are internal to happi and are subject to change.  Users should
+    interact with the :class:`happi.Client`.
+    """
 
     @property
     def all_devices(self):
         """List of all device sub-dictionaries."""
         raise NotImplementedError
+
+    def clear_cache(self) -> None:
+        """
+        Request to clear any cached data.
+
+        Optional implementation may be customized in subclass.
+        """
 
     def find(self, multiples=False, **kwargs):
         """

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -60,6 +60,7 @@ class JSONBackend(_Backend):
 
     def clear_cache(self) -> None:
         """Clear the loaded cache."""
+        print("cache clear")
         self._load_cache = None
 
     def _load_or_initialize(self):

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -60,7 +60,6 @@ class JSONBackend(_Backend):
 
     def clear_cache(self) -> None:
         """Clear the loaded cache."""
-        print("cache clear")
         self._load_cache = None
 
     def _load_or_initialize(self):

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -424,6 +424,9 @@ class QSBackend(JSONBackend):
 
     def __init__(self, expname, *, url=None, use_kerberos=True, user=None,
                  pw=None):
+        # Load cache is unused for this backend, but we have it here for
+        # API compatibility with the superclass JSONBackend.
+        self._load_cache = None
         # Create our client and gather the raw information from the client
         self._client = QuestionnaireClient(
             url=url, use_kerberos=use_kerberos, user=user, pw=pw


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Adds cache clearing mechanism to backends
* Each call to `client.search()` (and such) will hit the database once and cache internally
* User of client can further indicate that caching is to be done by way of the `retain_cache_context`
* Noted an additional performance issue: 
    * Search methods retrieve entire documents
    * When the client tries to instantiate a `HappiItem`, it hits the database again with just the identifier, retrieving the same document prior to instantiation
    * This is where the `_get_item_from_document` refactor comes in

## Motivation and Context
Addresses #235

## How Has This Been Tested?
Solely the test suite

## Where Has This Been Documented?
Issue and PR