### PR TITLE
ENH: use one cache for the entire cli search block

### DIFF
--- a/docs/source/upcoming_release_notes/267-use-search-cache.rst
+++ b/docs/source/upcoming_release_notes/267-use-search-cache.rst
@@ -1,0 +1,23 @@
+267 use-search-cache
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix a rare race condition related to reading a json device database
+  twice in a command line search command between database updates.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -145,65 +145,67 @@ def search_parser(
     range_list = []
     regex_list = []
     range_found = False
-    for user_arg in search_criteria:
-        if '=' in user_arg:
-            criteria, value = user_arg.split('=', 1)
-        else:
-            criteria = 'name'
-            value = user_arg
-        if criteria in client_args:
-            logger.error(
-                'Received duplicate search criteria %s=%r (was %r)',
-                criteria, value, client_args[criteria]
-            )
-            raise click.Abort()
 
-        if is_a_range(value):
-            start, stop = value.split(',')
-            start = float(start)
-            stop = float(stop)
-            if start < stop:
-                new_range_list = client.search_range(criteria, start, stop)
+    with client.retain_cache_context():
+        for user_arg in search_criteria:
+            if '=' in user_arg:
+                criteria, value = user_arg.split('=', 1)
             else:
-                logger.error('Invalid range, make sure start < stop')
+                criteria = 'name'
+                value = user_arg
+            if criteria in client_args:
+                logger.error(
+                    'Received duplicate search criteria %s=%r (was %r)',
+                    criteria, value, client_args[criteria]
+                )
                 raise click.Abort()
 
-            if not range_found:
-                # if first range, just replace
-                range_found = True
-                range_list = new_range_list
-            else:
-                # subsequent ranges, only take intersection
-                range_list = set(new_range_list) & set(range_list)
+            if is_a_range(value):
+                start, stop = value.split(',')
+                start = float(start)
+                stop = float(stop)
+                if start < stop:
+                    new_range_list = client.search_range(criteria, start, stop)
+                else:
+                    logger.error('Invalid range, make sure start < stop')
+                    raise click.Abort()
 
-            if not range_list:
-                # we have searched via a range query.  At this point
-                # no matches, or intesection is empty. abort early
-                logger.error('No devices found')
-                return []
+                if not range_found:
+                    # if first range, just replace
+                    range_found = True
+                    range_list = new_range_list
+                else:
+                    # subsequent ranges, only take intersection
+                    range_list = set(new_range_list) & set(range_list)
 
-            continue
+                if not range_list:
+                    # we have searched via a range query.  At this point
+                    # no matches, or intesection is empty. abort early
+                    logger.error('No devices found')
+                    return []
 
-        elif is_number(value):
-            if float(value) == int(float(value)):
-                # value is an int, allow the float version (optional .0)
-                logger.debug(f'looking for int value: {value}')
-                value = f'^{int(float(value))}(\\.0+$)?$'
-
-                # don't translate from glob
-                client_args[criteria] = value
                 continue
+
+            elif is_number(value):
+                if float(value) == int(float(value)):
+                    # value is an int, allow the float version (optional .0)
+                    logger.debug(f'looking for int value: {value}')
+                    value = f'^{int(float(value))}(\\.0+$)?$'
+
+                    # don't translate from glob
+                    client_args[criteria] = value
+                    continue
+                else:
+                    value = str(float(value))
             else:
-                value = str(float(value))
-        else:
-            logger.debug('Value %s interpreted as string', value)
+                logger.debug('Value %s interpreted as string', value)
 
-        if use_glob:
-            client_args[criteria] = fnmatch.translate(value)
-        else:  # already using regex
-            client_args[criteria] = value
+            if use_glob:
+                client_args[criteria] = fnmatch.translate(value)
+            else:  # already using regex
+                client_args[criteria] = value
 
-    regex_list = client.search_regex(**client_args)
+        regex_list = client.search_regex(**client_args)
 
     # Gather final results
     final_results = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Small follow-up to #265 
Here we force the search to use one cache for entire search (if applicable based on the backend).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Slightly more efficient: these searches will read the file exactly once instead of 1, 2, or 3ish times (or more with some inputs)
- Avoid issues with the database updating during a search and getting conflicting search results

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with:
```
$ happi profile --database z=0,1000 im1l1
```
And seeing the json reads drop from 2 to 1.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I need to run the pre-release thing
<!--
## Screenshots (if appropriate):
-->
