### PR TITLE
ENH: allow relative paths for json db in happi config

### DIFF
--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -7,10 +7,11 @@ import math
 import os
 import os.path
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import simplejson as json
 
+from .. import utils
 from ..errors import DuplicateError, SearchError
 from .core import _Backend
 
@@ -49,11 +50,18 @@ class JSONBackend(_Backend):
         Path to JSON file.
     initialze : bool, optional
         Initialize a new empty JSON file to begin filling.
+    cfg_path : str, optional
+        Path to the happi config.
     """
 
-    def __init__(self, path, initialize=False):
+    def __init__(self, path: str, initialize: bool = False, cfg_path: Optional[str] = None):
         self._load_cache = None
-        self.path = os.path.expanduser(path)
+        # Determine the cfg dir and build path to json db based on that unless we're initted w/o a config
+        if cfg_path is not None:
+            cfg_dir = os.path.dirname(cfg_path)
+            self.path = utils.build_abs_path(cfg_dir, path)
+        else:
+            self.path = path
         # Create a new JSON file if requested
         if initialize:
             self.initialize()

--- a/happi/backends/mongo_db.py
+++ b/happi/backends/mongo_db.py
@@ -32,6 +32,8 @@ class MongoBackend(_Backend):
         Database name within the MongoDB instance.
     timeout : float, optional
         Time to wait for connection attempt.
+    cfg_path : str, optional
+        Path to the happi config.
     """
 
     _timeout = 5
@@ -39,7 +41,7 @@ class MongoBackend(_Backend):
 
     def __init__(self, host=None, user=None,
                  pw=None, db=None, collection=None,
-                 timeout=None):
+                 timeout=None, cfg_path=None):
         # Default timeout
         timeout = timeout or self._timeout
         # Format connection string

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -418,12 +418,14 @@ class QSBackend(JSONBackend):
     pw : str, optional
         A password for ws_auth sign-in. If not provided a password will be
         requested.
+    cfg_path : str, optional
+        Path to the happi config.
     """
 
     translations = DEFAULT_TRANSLATIONS
 
-    def __init__(self, expname, *, url=None, use_kerberos=True, user=None,
-                 pw=None):
+    def __init__(self, expname: str, *, url=None, use_kerberos=True, user=None,
+                 pw=None, cfg_path=None):
         # Load cache is unused for this backend, but we have it here for
         # API compatibility with the superclass JSONBackend.
         self._load_cache = None

--- a/happi/client.py
+++ b/happi/client.py
@@ -849,7 +849,7 @@ class Client(collections.abc.Mapping):
 
         # Create our database with provided kwargs
         try:
-            database = backend(**db_kwargs)
+            database = backend(**db_kwargs, cfg_path=cfg)
             return cls(database=database)
         except Exception as ex:
             raise RuntimeError(

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -4,6 +4,7 @@ Basic module utilities
 import functools
 import keyword
 import logging
+import os
 import warnings
 from typing import Callable
 
@@ -118,3 +119,23 @@ def deprecated(message: str):
         return warn_and_call
 
     return wrapper
+
+
+def build_abs_path(basedir: str, path: str) -> str:
+    """
+    Builds an abs path starting at basedir if path is not already absolute.
+    ~ and ~user constructions will be expanded, so ~/path is considered absolute.
+    If path is absolute already, this function returns path without modification.
+
+    Parameters
+    ----------
+    basedir : str
+        If path is not absolute already, build an abspath
+        with path starting here.
+    path : str
+        The path to convert to absolute.
+    """
+    path = os.path.expanduser(path)
+    if not os.path.isabs(path):
+        return os.path.abspath(os.path.join(basedir, path))
+    return path


### PR DESCRIPTION
Paths to the json db can now be relative to the happi config, unless they're already absolute.

Resolves #188 

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

This allows paths to the json db to be relative to the happi config.

For the `device_config` repo, its `happi.cfg` can look like this, instead of containing an absolute path:
```
[DEFAULT]
path=db.json
```

Other relative paths will work fine too, ie `../device_config/db.json`m `./db.json`. Absolute paths are not transformed at all by the json backend when looking for the db, so `/reg/g/pcds/happi.cfg` will still mean `/reg/g/pcds/happi.cfg`. 


The solution I came up with for this isn't as clean as I'd like. Since each backend accepts arbitrary args from the happi config, there's no good way to process paths before sending them to the backend. Ultimately, it's up to the backend implementation to process any paths such that they're correct. Luckily, the only backend that relies on paths from the config is the json backend.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Our happi configs all have absolute paths in them, which makes them annoying to use 
outside of our LCLS environment. For example, I needed to modify the happi.cfg in our `device_config` repo so I could play around with the LCLS device db on my local machine.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

One test was modified to account for the new handling, and another test was added to specifically test configs with absolute paths for the json db.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Relevant comments have been modified or created in the code changed by this PR. I didn't see anything in the happi documentation that would need to be changed. 

<!--
## Screenshots (if appropriate):
-->
