### PR TITLE
DOC: container registry + update pre-release note tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,12 @@
 <!--
 ## Screenshots (if appropriate):
 -->
+
+## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive docstrings, including context and API
+- [ ] New/changed functions and methods are covered in the test suite where possible
+- [ ] Test suite passes locally
+- [ ] Test suite passes on continuous integration (Travis CI)
+- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
+- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate

--- a/docs/pre-release-notes.sh
+++ b/docs/pre-release-notes.sh
@@ -9,6 +9,16 @@ if [[ -z "$ISSUE" || -z "$DESCRIPTION" ]]; then
     exit 1
 fi
 
+re_issue_number='^[1-9][0-9]*$'
+
+if ! [[ "$ISSUE" =~ $re_issue_number ]]; then
+    echo "Error: Issue number is not a number: $ISSUE"
+    echo
+    echo "This should preferably be the issue number that this pull request solves."
+    echo "We may also accept the Pull Request number in place of the issue."
+    exit 1
+fi
+
 echo "Issue: $ISSUE"
 echo "Description: $DESCRIPTION"
 
@@ -24,4 +34,4 @@ if ${EDITOR} "${FILENAME}"; then
     git add "${FILENAME}"
 fi
 
-popd
+popd || exit 0

--- a/docs/source/upcoming_release_notes/270-lazy-registry.rst
+++ b/docs/source/upcoming_release_notes/270-lazy-registry.rst
@@ -1,0 +1,27 @@
+270 lazy registry
+#################
+
+API Changes
+-----------
+- The happi container registry now supports adding new container classes
+  manually by way of
+  ``happi.containers.registry["ContainerName"] = ContainerClass``.
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- The happi container registry is loaded at first use and not on import.  This
+  can result in increased performance where the happi database is not used.
+  It also fixes a scenario in which a module that defines a happi container
+  attempts to import certain classes from happi.
+
+Maintenance
+-----------
+- More documentation about the happi container registry was added.
+
+Contributors
+------------
+- klauer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add missing pre-release notes from #270 
* Updated pre-release tool (synchronized with pcdsdevices)
* Updated pull request template to include a pre-merge checklist (from pcdsdevices)

## Motivation and Context
* I forget which repositories have pre-release notes.  
* The checklist is good for us and contributors.

## How Has This Been Tested?
`$ make html` works

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (Travis CI)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate