### PR TITLE
ENH: Improve error handling and logging for happi CLI

### DIFF
--- a/docs/source/upcoming_release_notes/278-Improve_error_handling_and_logging_in_the_happi_cli.rst
+++ b/docs/source/upcoming_release_notes/278-Improve_error_handling_and_logging_in_the_happi_cli.rst
@@ -1,0 +1,22 @@
+278 Improve error handling and logging in the happi cli
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Improved error logging in happi CLI to be more consistent
+
+Bugfixes
+--------
+- Removed extraneous extraneous print in `happi load`
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- JJL772


### PR DESCRIPTION

Improve some of the error handling and logging in happi CLI.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Error handling was previously a combination of `click.Abort()`, `print` and `logger.XXX` functions for the CLI interface. This PR consolidates this handling into `raise click.ClickException(message)` where applicable. Most of the instances changed here were related to user input validation, which probably doesn't need to be logged with the "proper" logging interface in the first place.

There were also a couple instances where an exception was unhandled, this PR fixes those too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Originally I was only going to address the unhanded exceptions here, but I decided that it might be good to consolidate the logging for CLI and make it more consistent. This improves the overall "user experience" for the command line, as exceptions are caught and displayed gracefully to the user, and the logging is more consistent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested this by typing random stuff into the happi cli and seeing what fails/doesnt. A couple tests were modified to accommodate this change. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (Travis CI)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
