### PR TITLE
ENH: allow filtering of kwargs that have a value matching the default

### DIFF
--- a/docs/source/upcoming_release_notes/282-enh_filter_default_kwargs.rst
+++ b/docs/source/upcoming_release_notes/282-enh_filter_default_kwargs.rst
@@ -1,0 +1,25 @@
+282 enh_filter_default_kwargs
+#############################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- adds flag ``include_default_as_kwarg``.  If False on a kwargs EntryInfo,
+  any values that match the default on the corresponding EntryInfo will be
+  omitted from the kwarg dictionary.
+  The default value is True, retaining the original behavior.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/282-enh_filter_default_kwargs.rst
+++ b/docs/source/upcoming_release_notes/282-enh_filter_default_kwargs.rst
@@ -7,9 +7,11 @@ API Changes
 
 Features
 --------
-- adds flag ``include_default_as_kwarg``.  If False on a kwargs EntryInfo,
-  any values that match the default on the corresponding EntryInfo will be
-  omitted from the kwarg dictionary.
+- Add `EntryInfo` keyword argument ``include_default_as_kwarg``.  If set to ``False``,
+  any keys that are included in an item's ``kwargs`` that match the default of their
+  corresponding `EntryInfo` will be omitted from the keyword arguments passed to
+  ``device_class`` when instantiating (loading) the item as in ``happi.loader.load_device`` or
+  ``SearchResult.get()``.
   The default value is True, retaining the original behavior.
 
 Bugfixes

--- a/docs/source/upcoming_release_notes/282-enh_filter_default_kwargs.rst
+++ b/docs/source/upcoming_release_notes/282-enh_filter_default_kwargs.rst
@@ -7,12 +7,17 @@ API Changes
 
 Features
 --------
-- Add `EntryInfo` keyword argument ``include_default_as_kwarg``.  If set to ``False``,
+- Add ``EntryInfo`` keyword argument ``include_default_as_kwarg``.  If set to ``False``,
   any keys that are included in an item's ``kwargs`` that match the default of their
-  corresponding `EntryInfo` will be omitted from the keyword arguments passed to
+  corresponding ``EntryInfo`` will be omitted from the keyword arguments passed to
   ``device_class`` when instantiating (loading) the item as in ``happi.loader.load_device`` or
   ``SearchResult.get()``.
-  The default value is True, retaining the original behavior.
+  If the ``kwargs`` EntryInfo sets ``include_default_as_kwarg = True``,
+  the setting on the corresponding ``EntryInfo`` will be used to decide
+  whether or not to omit a keyword argument.
+  If the ``kwargs`` EntryInfo sets ``include_default_as_kwarg = False``,
+  the setting on corresponding ``EntryInfo`` will be ignored.
+  The default value is True on all EntryInfo instances, retaining the original behavior.
 
 Bugfixes
 --------

--- a/happi/item.py
+++ b/happi/item.py
@@ -81,7 +81,7 @@ class EntryInfo:
         enforce: Optional[Any] = None,
         default: Optional[Any] = None,
         enforce_doc: Optional[str] = None,
-        include_default_as_kwarg: Optional[bool] = True
+        include_default_as_kwarg: bool = True
     ):
         self.key = None  # Set later by parent class
         self.doc = doc

--- a/happi/item.py
+++ b/happi/item.py
@@ -50,7 +50,7 @@ class EntryInfo:
         if the entered information does not follow the ``enforce`` type
     include_default_as_kwarg : bool, optional
         Defaults to True.  If a kwargs EntryInfo sets this to False, all kwargs
-        will be compared to their corresponding Entries in the item. and
+        will be compared to their corresponding Entries in the item and
         omitted from the kwargs dictionary if their value matches the Entry's
         default.
         This can also be set on an individual Entry basis.  The setting on

--- a/happi/item.py
+++ b/happi/item.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import sys
 from collections import OrderedDict
+from typing import Any, Optional
 
 from prettytable import PrettyTable
 
@@ -65,13 +66,20 @@ class EntryInfo:
                                  enforce_doc='This must be a number')
     """
 
-    def __init__(self, doc=None, optional=True, enforce=None,
-                 default=None, enforce_doc=None, filter_none=False):
+    def __init__(
+        self,
+        doc: Optional[str] = None,
+        optional: Optional[bool] = True,
+        enforce: Optional[Any] = None,
+        default: Optional[Any] = None,
+        enforce_doc: Optional[str] = None,
+        include_default_as_kwarg: Optional[bool] = True
+    ):
         self.key = None  # Set later by parent class
         self.doc = doc
         self.enforce = enforce
         self.optional = optional
-        self.filter_none = filter_none
+        self.include_default_as_kwarg = include_default_as_kwarg
         self.enforce_doc = str(enforce_doc or '')
 
         # Explicitly set default to None b/c this is how we ensure mandatory

--- a/happi/item.py
+++ b/happi/item.py
@@ -48,6 +48,14 @@ class EntryInfo:
     enforce_doc : str, optional
         A human-readable explanation of the enforce field.  Will be printed
         if the entered information does not follow the ``enforce`` type
+    include_default_as_kwarg : bool, optional
+        Defaults to True.  If a kwargs EntryInfo sets this to False, all kwargs
+        will be compared to their corresponding Entries in the item. and
+        omitted from the kwargs dictionary if their value matches the Entry's
+        default.
+        This can also be set on an individual Entry basis.  The setting on
+        an individual entry will only be taken into consideration if the
+        kwarg EntryInfo has this set to True (default).
 
     Raises
     ------

--- a/happi/item.py
+++ b/happi/item.py
@@ -66,11 +66,12 @@ class EntryInfo:
     """
 
     def __init__(self, doc=None, optional=True, enforce=None,
-                 default=None, enforce_doc=None):
+                 default=None, enforce_doc=None, filter_none=False):
         self.key = None  # Set later by parent class
         self.doc = doc
         self.enforce = enforce
         self.optional = optional
+        self.filter_none = filter_none
         self.enforce_doc = str(enforce_doc or '')
 
         # Explicitly set default to None b/c this is how we ensure mandatory

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -182,7 +182,6 @@ def from_container(
         new_kwargs = {k: v for k, v in kwargs.items() if v is not None}
         kwargs = new_kwargs
     # Return the instantiated item
-    print(kwargs)
     obj = cls(*args, **kwargs)
     # Attach the metadata to the object
     if attach_md:

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -178,8 +178,12 @@ def from_container(
     kwargs = dict((key, create_arg(val))
                   for key, val in item.kwargs.items())
     # maybe filter out null kwargs
-    if item._info_attrs['kwargs'].filter_none:
-        new_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    if not item._info_attrs['kwargs'].include_default_as_kwarg:
+        new_kwargs = {}
+        for k, v in kwargs.items():
+            einfo = item._info_attrs.get(k, False)
+            if not einfo or not einfo.default == v:
+                new_kwargs[k] = v
         kwargs = new_kwargs
     # Return the instantiated item
     obj = cls(*args, **kwargs)

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -177,8 +177,10 @@ def from_container(
     args = [create_arg(arg) for arg in item.args]
     kwargs = dict((key, create_arg(val))
                   for key, val in item.kwargs.items())
+    # filter out null kwargs
+    new_kwargs = {k: v for k, v in kwargs.items() if v is not None}
     # Return the instantiated item
-    obj = cls(*args, **kwargs)
+    obj = cls(*args, **new_kwargs)
     # Attach the metadata to the object
     if attach_md:
         try:

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -177,10 +177,13 @@ def from_container(
     args = [create_arg(arg) for arg in item.args]
     kwargs = dict((key, create_arg(val))
                   for key, val in item.kwargs.items())
-    # filter out null kwargs
-    new_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    # maybe filter out null kwargs
+    if item._info_attrs['kwargs'].filter_none:
+        new_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        kwargs = new_kwargs
     # Return the instantiated item
-    obj = cls(*args, **new_kwargs)
+    print(kwargs)
+    obj = cls(*args, **kwargs)
     # Attach the metadata to the object
     if attach_md:
         try:

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -180,10 +180,10 @@ def from_container(
     # maybe filter out null kwargs
     if not item._info_attrs['kwargs'].include_default_as_kwarg:
         new_kwargs = {}
-        for k, v in kwargs.items():
-            einfo = item._info_attrs.get(k, False)
-            if not einfo or not einfo.default == v:
-                new_kwargs[k] = v
+        for entry, value in kwargs.items():
+            einfo = item._info_attrs.get(entry, False)
+            if not einfo or not einfo.default == value:
+                new_kwargs[entry] = value
         kwargs = new_kwargs
     # Return the instantiated item
     obj = cls(*args, **kwargs)

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -81,9 +81,10 @@ def item(item_info: Dict[str, Any]) -> OphydItem:
 
 
 class JinjaItem(OphydItem):
-    blank_list = EntryInfo('to be set to None', enforce=list)
-    blank_str = EntryInfo('to be set to None', enforce=str)
-    blank_bool = EntryInfo('to be set to None', enforce=bool)
+    blank_list = EntryInfo('a list', enforce=list, default=[1, 2, 3])
+    blank_str = EntryInfo('a string', enforce=str, default='blank')
+    blank_bool = EntryInfo('a bool', enforce=bool, default=True)
+    blank_none = EntryInfo('default is None')
 
 
 @pytest.fixture(scope='function')
@@ -102,13 +103,15 @@ def item_info_jinja() -> Dict[str, Any]:
                 'blank_list': '{{blank_list}}',
                 'blank_str': '{{blank_str}}',
                 'blank_bool': '{{blank_bool}}',
+                'blank_none': '{{blank_none}}',
                 'blank': '{{blank}}'
             },
             'location_group': 'LOC',
             'functional_group': 'FUNC',
-            'blank_list': None,
-            'blank_str': None,
-            'blank_bool': None,
+            'blank_list': [1, 2, 3],
+            'blank_str': 'blank',
+            'blank_bool': True,
+            'blank_none': None,
             'blank': None
             }
 

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -80,6 +80,44 @@ def item(item_info: Dict[str, Any]) -> OphydItem:
     return OphydItem(**item_info)
 
 
+class JinjaItem(OphydItem):
+    blank_list = EntryInfo('to be set to None', enforce=list)
+    blank_str = EntryInfo('to be set to None', enforce=str)
+    blank_bool = EntryInfo('to be set to None', enforce=bool)
+
+
+@pytest.fixture(scope='function')
+def item_info_jinja() -> Dict[str, Any]:
+    return {'name': 'alias',
+            'z': 400,
+            '_id': 'alias',
+            'prefix': 'BASE:PV',
+            'beamline': 'LCLS',
+            'type': 'OphydItem',
+            'device_class': 'types.SimpleNamespace',
+            'args': list(),
+            'kwargs': {
+                'hi': 'oh hello',
+                'loc': '{{location_group}}',
+                'blank_list': '{{blank_list}}',
+                'blank_str': '{{blank_str}}',
+                'blank_bool': '{{blank_bool}}',
+                'blank': '{{blank}}'
+            },
+            'location_group': 'LOC',
+            'functional_group': 'FUNC',
+            'blank_list': None,
+            'blank_str': None,
+            'blank_bool': None,
+            'blank': None
+            }
+
+
+@pytest.fixture(scope='function')
+def item_jinja(item_info_jinja: Dict[str, Any]) -> OphydItem:
+    return JinjaItem(**item_info_jinja)
+
+
 @pytest.fixture(scope='function')
 def valve_info() -> Dict[str, Any]:
     return {'name': 'name',

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -84,6 +84,9 @@ class JinjaItem(OphydItem):
     blank_list = EntryInfo('a list', enforce=list, default=[1, 2, 3])
     blank_str = EntryInfo('a string', enforce=str, default='blank')
     blank_bool = EntryInfo('a bool', enforce=bool, default=True)
+    blank_exclude = EntryInfo('omitted if default',
+                              default='default',
+                              include_default_as_kwarg=False)
     blank_none = EntryInfo('default is None')
 
 
@@ -104,6 +107,7 @@ def item_info_jinja() -> Dict[str, Any]:
                 'blank_str': '{{blank_str}}',
                 'blank_bool': '{{blank_bool}}',
                 'blank_none': '{{blank_none}}',
+                'blank_exclude': '{{blank_exclude}}',
                 'blank': '{{blank}}'
             },
             'location_group': 'LOC',
@@ -112,6 +116,7 @@ def item_info_jinja() -> Dict[str, Any]:
             'blank_str': 'blank',
             'blank_bool': True,
             'blank_none': None,
+            'blank_exclude': 'default',
             'blank': None
             }
 

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -110,15 +110,15 @@ def trim_split_output(strings: str, delim: str = '\n'):
     """
     date_pattern = r"\[(\d{4})[-](0[1-9]|1[012])[-].*\]"
 
-    bad_substrs = [r"^pcdsdevices"]
+    ok_substrs = [r"happi.item."]
 
     # remove registry items
     new_out = [
         st for st in strings.split(delim)
-        if not any([re.search(substr, st) for substr in bad_substrs])
+        if any([re.search(substr, st) for substr in ok_substrs])
     ]
 
-    # string date-time from logging messages
+    # strip date-time from logging messages
     new_out = [re.sub(date_pattern, '', st) for st in new_out]
     return new_out
 

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -127,6 +127,7 @@ def test_load_devices(threaded: bool, post_load: Any, include_load_time: bool):
 def test_filter_kwargs(item_jinja: OphydItem):
     blanks = ['blank_bool', 'blank_list', 'blank_str', 'blank_none']
 
+    # default behavior, allow individuals to decide
     item_jinja._info_attrs['kwargs'].include_default_as_kwarg = True
     dev = from_container(item_jinja, use_cache=False)
 
@@ -137,12 +138,14 @@ def test_filter_kwargs(item_jinja: OphydItem):
     # if there is no correspoding EntryInfo, this is a piece of metadata
     # type cannot be matched and value will be returned as string
     assert dev.blank == 'None'
+    assert getattr(dev, 'blank_exclude', 'DNE') == 'DNE'
     for bl in blanks:
         assert getattr(dev, bl, 'DNE') == item_jinja._info_attrs[bl].default
 
     item_jinja._info_attrs['kwargs'].include_default_as_kwarg = False
     filtered_dev = from_container(item_jinja, use_cache=False)
 
-    assert dev.blank == 'None'
+    assert filtered_dev.blank == 'None'
+    assert getattr(filtered_dev, 'blank_exclude', 'DNE') == 'DNE'
     for bl in blanks:
         assert getattr(filtered_dev, bl, 'DNE') == 'DNE'

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -122,3 +122,27 @@ def test_load_devices(threaded: bool, post_load: Any, include_load_time: bool):
     import datetime
     assert space.test_1 == datetime.timedelta(days=10, seconds=30)
     assert isinstance(space.bad, ImportError)
+
+
+def test_filter_kwargs(item_jinja: OphydItem):
+    blanks = ['blank_bool', 'blank_list', 'blank_str']
+
+    item_jinja._info_attrs['kwargs'].filter_none = False
+    dev = from_container(item_jinja, use_cache=False)
+
+    # basic jinja template filling test.
+    # only kwargs get attrs in SimpleNamespace
+    assert dev.loc == 'LOC'
+
+    # if there is no correspoding EntryInfo, this is a piece of metadata
+    # type cannot be matched and value will be returned as string
+    assert dev.blank == 'None'
+    for bl in blanks:
+        assert getattr(dev, bl, 'DNE') is None
+
+    item_jinja._info_attrs['kwargs'].filter_none = True
+    filtered_dev = from_container(item_jinja, use_cache=False)
+
+    assert dev.blank == 'None'
+    for bl in blanks:
+        assert getattr(filtered_dev, bl, 'DNE') == 'DNE'

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -125,9 +125,9 @@ def test_load_devices(threaded: bool, post_load: Any, include_load_time: bool):
 
 
 def test_filter_kwargs(item_jinja: OphydItem):
-    blanks = ['blank_bool', 'blank_list', 'blank_str']
+    blanks = ['blank_bool', 'blank_list', 'blank_str', 'blank_none']
 
-    item_jinja._info_attrs['kwargs'].filter_none = False
+    item_jinja._info_attrs['kwargs'].include_default_as_kwarg = True
     dev = from_container(item_jinja, use_cache=False)
 
     # basic jinja template filling test.
@@ -138,9 +138,9 @@ def test_filter_kwargs(item_jinja: OphydItem):
     # type cannot be matched and value will be returned as string
     assert dev.blank == 'None'
     for bl in blanks:
-        assert getattr(dev, bl, 'DNE') is None
+        assert getattr(dev, bl, 'DNE') == item_jinja._info_attrs[bl].default
 
-    item_jinja._info_attrs['kwargs'].filter_none = True
+    item_jinja._info_attrs['kwargs'].include_default_as_kwarg = False
     filtered_dev = from_container(item_jinja, use_cache=False)
 
     assert dev.blank == 'None'


### PR DESCRIPTION
## Description
- Adds the kwarg `include_default_as_kwarg` to `EntryInfo`
- Adds a clause in `from_container` to omit `kwargs` if their value is equal to the default stored on the corresponding `EntryInfo`, triggered by the `item._info_attrs['kwargs'].include_default_as_kwarg` flag.
  - Gives individual `EntryInfo`'s the ability to decide whether or not to `include_default_as_kwarg` in the case where `item._info_attrs['kwargs'].include_default_as_kwarg = True`
- adds tests for this feature and a fixture that covers jinja template code paths

What is the behavior now?  Considering the case where we are attmpting to load a device from the following document:
```yaml
{
    'name': 'alias',
    ...
    'kwargs': {
        'hi': 'oh hello',
        'blank': '{{blank}}'
        },
    'blank': 'default_blank'
}
```
- `'hi' = 'oh hello'` will always be passed through as a kwarg
- `blank` 's value will depend on the container
  - if `blank` has no corresponding `EntryInfo` --> `blank = 'default_blank'`
    - if include_default_as_kwarg == True: `kwargs = {'hi': 'oh hello', 'blank': 'default_blank'}`
    - if include_default_as_kwarg == False: `kwargs = {'hi': 'oh hello', 'blank': 'default_blank'}` (no effect)
  - if `blank` has an `EntryInfo` and its default is 'default_blank' --> 
    - if include_default_as_kwarg == True: `kwargs = {'hi': 'oh hello', 'blank' = 'default_blank'}`
    - if include_default_as_kwarg == False: `kwargs = {'hi': 'oh hello'}`

- All `EntryInfo`'s have this setting.  You can change this setting either on the kwargs EntryInfo, or a non-kwargs EntryInfo
  - If the kwargs EntryInfo sets `include_default_as_kwarg = True` (default)
    - Consult the corresponding `EntryInfo`'s setting for each kwarg for whether to include the default or not
  - if the kwargs EntryInfo sets `include_default_as_kwarg  = False`
    - Ignore the corresponding `EntryInfo` setting.  Ignore any kwarg whose value matches the EntryInfo default

## Motivation and Context
Closes #281 
I wanted a way to ignore a kwarg if it isn't filled with relevant information.  

Is this the behavior we want?
- The default behavior is unchanged, and the flag makes it possible to opt-in to this new behavior
- I would argue that if a piece of information lacks an `EntryInfo`, it is metadata, and should be carried through
- if there is an EntryInfo and it is being passed as a kwarg, we have to leave it to the user to decide whether they actually want to pass `None` as a kwarg

Why add this flag to all `EntryInfo` instances when only `kwargs` cares?
- I felt that making a separate subclass of `EntryInfo` just for kwargs would cause more confusion than it's worth.  Though I could be convinced othewise


## How Has This Been Tested?
interactively, and a test has been added to the test suite. 

## Where Has This Been Documented?
comments, this PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (Travis CI)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
