### PR TITLE
MNT: set a max width for item.show_info tables

### DIFF
--- a/docs/source/upcoming_release_notes/284-mnt_max_table_width.rst
+++ b/docs/source/upcoming_release_notes/284-mnt_max_table_width.rst
@@ -1,0 +1,22 @@
+284 mnt_max_table_width
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- calculates a max width for the table based on the current terminal size
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/item.py
+++ b/happi/item.py
@@ -1,6 +1,7 @@
 import collections
 import copy
 import logging
+import os
 import sys
 from collections import OrderedDict
 from typing import Any, Optional
@@ -335,7 +336,6 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
         """
 
         pt = PrettyTable(['EntryInfo', 'Value'])
-        pt._max_width = {'Value': 60}
         pt.align = 'r'
         pt.align['EntryInfo'] = 'l'
         pt.align['Value'] = 'l'
@@ -348,6 +348,15 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
                               if not key.startswith('_')])
         for key in public_keys:
             pt.add_row([key, show_info[key]])
+
+        # initialize table so we can grab widths
+        _ = pt.get_string()
+
+        # set width of Value column dynamically
+        # set width(Value) = terminal width - width(EntryInfo column)
+        entry_info_width = pt._widths[0] + 10  # account for padding
+        term_width = os.get_terminal_size()[0]
+        pt._max_width = {'Value': max(60, term_width - entry_info_width)}
 
         print(pt, file=handle)
 

--- a/happi/item.py
+++ b/happi/item.py
@@ -335,6 +335,7 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
         """
 
         pt = PrettyTable(['EntryInfo', 'Value'])
+        pt._max_width = {'Value': 60}
         pt.align = 'r'
         pt.align['EntryInfo'] = 'l'
         pt.align['Value'] = 'l'

--- a/happi/item.py
+++ b/happi/item.py
@@ -357,10 +357,10 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
         entry_info_width = pt._widths[0] + 10  # account for padding
         try:
             term_width = os.get_terminal_size()[0]
+            pt._max_width = {'Value': max(60, term_width - entry_info_width)}
         except OSError:
-            term_width = 0
-
-        pt._max_width = {'Value': max(60, term_width - entry_info_width)}
+            # non-interactive mode (piping results). No max width
+            pass
 
         print(pt, file=handle)
 

--- a/happi/item.py
+++ b/happi/item.py
@@ -355,7 +355,11 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
         # set width of Value column dynamically
         # set width(Value) = terminal width - width(EntryInfo column)
         entry_info_width = pt._widths[0] + 10  # account for padding
-        term_width = os.get_terminal_size()[0]
+        try:
+            term_width = os.get_terminal_size()[0]
+        except OSError:
+            term_width = 0
+
         pt._max_width = {'Value': max(60, term_width - entry_info_width)}
 
         print(pt, file=handle)


### PR DESCRIPTION
## Description
Calculates a max width for tables generated by `item.show_info()` based on the current terminal width

## Motivation and Context
After I added a bunch of kwargs, the tables got annoying to view.  

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR.

Before
![image](https://user-images.githubusercontent.com/35379409/182225847-46af4268-cb13-404f-9be8-963c79883155.png)

After
![image](https://user-images.githubusercontent.com/35379409/182226499-03e31f9e-18aa-4c5d-b16e-369a6defea39.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (Travis CI)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
