### PR TITLE
ENH: fallback to normal Python shell if IPython is not found

### DIFF
--- a/happi/cli.py
+++ b/happi/cli.py
@@ -364,8 +364,16 @@ def load(ctx, item_names: List[str]):
         except SearchError as e:
             raise click.ClickException(f'Could not load device {name!r}: {e}')
 
-    from IPython import start_ipython  # noqa
-    start_ipython(argv=['--quick'], user_ns=devices)
+    try:
+        from IPython import start_ipython  # noqa
+        start_ipython(argv=['--quick'], user_ns=devices)
+    except ImportError:
+        # Fall back to normal Python REPL if IPython is not available
+        import code
+        vars = globals().copy()
+        vars.update(devices)
+        shell = code.InteractiveConsole(vars)
+        shell.interact()
 
 
 # TODO: FIgure out how to deal with json and click.  list of args doesn't


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Fallback to normal Python shell if IPython is not installed.

Closes #259

The code here is basically the same as what's found in the stackoverflow post linked in #259.
I'm copying all globals and `devices` here, not sure if I should copy the rest of the locals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Just resolving a simple issue on a Friday!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested interactively, no unit tests are needed for this.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

N/A?

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on continuous integration (Travis CI)
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
