### PR TITLE
ENH: Simultaneous Multi-Backend support

### DIFF
--- a/docs/source/upcoming_release_notes/287-enh_multi_backend.rst
+++ b/docs/source/upcoming_release_notes/287-enh_multi_backend.rst
@@ -1,0 +1,24 @@
+287 enh_multi_backend
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds MultiBackend, which allows a happi Client to serve information
+  from multiple databases simultaneously.  Updates config parsing logic
+  to match.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/backends/__init__.py
+++ b/happi/backends/__init__.py
@@ -15,6 +15,9 @@ def _get_backend(backend):
     if backend == 'qs':
         from .qs_db import QSBackend
         return QSBackend
+    if backend == 'multi':
+        from .multi_db import MultiBackend
+        return MultiBackend
     raise ValueError(f'Unknown backend {backend!r}')
 
 
@@ -35,6 +38,11 @@ def _get_backends():
         backends['qs'] = _get_backend('qs')
     except ImportError as ex:
         logger.debug('Questionnaire backend unavailable: %s', ex)
+
+    try:
+        backends['multi'] = _get_backend('multi')
+    except ImportError as ex:
+        logger.debug('Multi backend unavailable: %s', ex)
 
     return backends
 

--- a/happi/backends/core.py
+++ b/happi/backends/core.py
@@ -2,8 +2,13 @@
 Base backend database options.
 """
 import logging
+from typing import Any, Dict, Generator, List
 
 logger = logging.getLogger(__name__)
+
+
+ItemMeta = Dict[str, Any]
+ItemMetaGen = Generator[ItemMeta, None, None]
 
 
 class _Backend:
@@ -15,7 +20,7 @@ class _Backend:
     """
 
     @property
-    def all_items(self):
+    def all_items(self) -> List[ItemMeta]:
         """
         List of all items in the database.
 
@@ -31,7 +36,7 @@ class _Backend:
         Optional implementation may be customized in subclass.
         """
 
-    def find(self, multiples=False, **kwargs):
+    def find(self, multiples: bool = False, **kwargs) -> ItemMetaGen:
         """
         Find an instance or instances that matches the search criteria.
 
@@ -48,7 +53,12 @@ class _Backend:
         """
         raise NotImplementedError
 
-    def save(self, _id, post, insert=True):
+    def save(
+        self,
+        _id: str,
+        post: Dict[str, Any],
+        insert: bool = True
+    ) -> None:
         """
         Save information to the database.
 
@@ -77,7 +87,7 @@ class _Backend:
         """
         raise NotImplementedError
 
-    def delete(self, _id):
+    def delete(self, _id: str) -> None:
         """
         Delete a device instance from the database.
 

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -173,10 +173,10 @@ class JSONBackend(_Backend):
             except Exception as ex:
                 logger.debug('Comparison method failed: %s', ex, exc_info=ex)
 
-    def get_by_id(self, _id: str) -> ItemMeta:
+    def get_by_id(self, id_: str) -> ItemMeta:
         """Get an item by ID if it exists, or return None."""
         db = self._load_or_initialize()
-        return db.get(_id)
+        return db.get(id_)
 
     def find(self, to_match: Dict[str, Any]) -> ItemMetaGen:
         """

--- a/happi/backends/multi_db.py
+++ b/happi/backends/multi_db.py
@@ -31,7 +31,7 @@ def prevent_duplicate_ids(fn):
 
 class MultiBackend(_Backend):
     """
-    Multi-file backend.
+    Multi-backend backend.
 
     Combines multiple backends, prioritizing database files in order
     of appearance.
@@ -93,7 +93,7 @@ class MultiBackend(_Backend):
 
         Yields
         ------
-        ItemMetaGen
+        Dict[str, Any]
             A generator of metadata documents
         """
         for bknd in self.backends:
@@ -101,13 +101,13 @@ class MultiBackend(_Backend):
 
     def save(self, _id, post, insert=True):
         """The current implementation of this backend is read-only."""
-        raise NotImplementedError("The Questionnaire backend is read-only")
+        raise NotImplementedError("The Multi-backend backend is read-only")
 
     def delete(self, _id):
         """The current implementation of this backend is read-only."""
-        raise NotImplementedError("The Questionnaire backend is read-only")
+        raise NotImplementedError("The Multi-backend backend is read-only")
 
-    def get_by_id(self, id_: str) -> ItemMeta:
+    def get_by_id(self, id_: str) -> Optional[ItemMeta]:
         """
         Get an document by ID if it exists, or return None.
 
@@ -120,7 +120,7 @@ class MultiBackend(_Backend):
 
         Returns
         -------
-        ItemMeta
+        Dict[str, Any] or None
             The requested metadata document
         """
         for bknd in self.backends:
@@ -159,8 +159,8 @@ class MultiBackend(_Backend):
 
         Yields
         ------
-        ItemMetaGen
-            A generator of metadata documents
+        Dict[str, Any]
+            metadata documents matching the provided range
         """
         for bknd in self.backends:
             yield from bknd.find_range(key, start=start, stop=stop,
@@ -186,8 +186,8 @@ class MultiBackend(_Backend):
 
         Yields
         ------
-        ItemMetaGen
-            A generator of metadata documents
+        Dict[str, Any]
+            matching metadata documents
         """
         for bknd in self.backends:
             yield from bknd.find_regex(to_match, flags=flags)

--- a/happi/backends/multi_db.py
+++ b/happi/backends/multi_db.py
@@ -1,0 +1,147 @@
+"""
+Backend implementation that combines multiple backends.
+"""
+import functools
+import logging
+import os
+import re
+from typing import Any, Dict, Generator, List, Union
+
+from .core import _Backend
+
+logger = logging.getLogger(__name__)
+
+PathLike = Union[str, bytes, os.PathLike]
+ItemMeta = Dict[str, Any]
+
+
+def prevent_duplicate_ids(fn):
+    """
+    Decorator that remembers which document _id's have been yielded and
+    prevents subsequent documents with matching _id's from being yielded
+    """
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        unique_ids = set()
+        for doc in fn(*args, **kwargs):
+            if doc['_id'] not in unique_ids:
+                unique_ids.add(doc['_id'])
+                yield doc
+
+    return wrapper
+
+
+class MultiBackend(_Backend):
+    """
+    Multi-file backend.
+
+    Combines multiple backends, prioritizing database files in order
+    of appearance.
+
+    """
+    def __init__(self, backends: List[_Backend]):
+        self._load_cache = None
+
+        self.backends = backends
+
+    @property
+    def all_items(self) -> List[ItemMeta]:
+        """
+        List of all items in all backends.
+
+        In the case of duplicate items, the item in the first backend
+        takes priority.
+        """
+        items = []
+        unique_ids = set()
+        for bknd in self.backends:
+            curr_items = bknd.all_items
+            for doc in curr_items:
+                if doc['_id'] not in unique_ids:
+                    items.append(doc)
+                    unique_ids.add(doc['_id'])
+
+        return items
+
+    def clear_cache(self) -> None:
+        """
+        Request to clear any cached data.
+
+        Clears the cache of each backend
+        """
+        for bknd in self.backends:
+            bknd.clear_cache()
+
+    @prevent_duplicate_ids
+    def find(
+        self,
+        *args,
+        multiples=False,
+        **kwargs
+    ) -> Generator[ItemMeta, None, None]:
+        """
+        Find an instance or instances that matches the search criteria.
+
+        Parameters
+        ----------
+        multiples : bool
+            Find a single result or all results matching the provided
+            information.
+        kwargs
+            Requested information.
+        """
+        for bknd in self.backends:
+            yield from bknd.find(*args, **kwargs)
+
+    def save(self, _id, post, insert=True):
+        """The current implementation of this backend is read-only."""
+        raise NotImplementedError("The Questionnaire backend is read-only")
+
+    def delete(self, _id):
+        """The current implementation of this backend is read-only."""
+        raise NotImplementedError("The Questionnaire backend is read-only")
+
+    def get_by_id(self, id_) -> ItemMeta:
+        """
+        Get an document by ID if it exists, or return None.
+
+        Returns the first match, in config priority
+        """
+        for bknd in self.backends:
+            doc = bknd.get_by_id(id_)
+            if doc:
+                return doc
+
+        return
+
+    @prevent_duplicate_ids
+    def find_range(self, key, *, start, stop=None, to_match) -> Generator[ItemMeta, None, None]:
+        """
+        Find instances that match the search criteria, such that
+        ``start <= entry[key] < stop``.
+
+        Should check for duplicates
+
+        Parameters
+        ----------
+        key : _type_
+            _description_
+        start : _type_
+            _description_
+        to_match : _type_
+            _description_
+        stop : _type_, optional
+            _description_, by default None
+
+        Yields
+        ------
+        Generator[ItemMeta, None, None]
+            _description_
+        """
+        for bknd in self.backends:
+            yield from bknd.find_range(key, start=start, stop=stop, to_match=to_match)
+
+    @prevent_duplicate_ids
+    def find_regex(self, to_match, *, flags=re.IGNORECASE):
+        for bknd in self.backends:
+            yield from bknd.find_regex(to_match, flags=flags)


### PR DESCRIPTION
## Description
- Creates MultiBackend, which itself takes multiple backends.
  - MultiBackend prioritizes backends in the order they are listed in the config, with the DEFAULT config used last

## Motivation and Context
closes #24 ... some things never change
If users have small, hutch-specific configuration changes to the happi database, previously they would have to direct happi to their own version of the database.  This allows users to incorporate a small db file on top of our facility-wide device_config, which acts as a fallback.

### Config file
Currently our config files have only the path to a single db file, with the option to specify a backend and its associated initialization arguments

```
[DEFAULT]
path = /cds/home/r/path/to/db.json
```

This PR allows sections other than `DEFAULT` to specify additional backends.   If more than one backend (section) is detected at config-read-time, a MultiBackend will be initialized with those backends.  `DEFAULT` is given the lowest priority, and the remaining backends will be prioritized in order of appearance.

```
[CONFIG1]
# will take precedence over DEFAULT and CONFIG1
path = /cds/home/r/path/to/db1.json

[DEFAULT]
path = /cds/home/r/path/to/db.json

[CONFIG2]
# will take precedence over DEFAULT, but duplicates present in CONFIG1 will not be seen
path = /cds/home/r/path/to/db2.json
```

## How Has This Been Tested?
A test has been added, interactive testing 

## Where Has This Been Documented?
This PR, docstrings, type-hints.  Config file documentation is forthcoming, if this looks good

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (Travis CI)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
