### PR TITLE
ENH: add delete cli command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ env:
 
     # Extra dependencies needed to run the tests which are not included
     # at the recipe and dev-requirements.txt. E.g. PyQt
-    - CONDA_EXTRAS="pcdsdevices pcdsutils line_profiler"
+    - CONDA_EXTRAS="pcdsdevices pcdsutils line_profiler<4.0.0"
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip
-    - PIP_EXTRAS="pcdsdevices pcdsutils line-profiler"
+    - PIP_EXTRAS="pcdsdevices pcdsutils line-profiler<4.0.0"
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/docs/source/upcoming_release_notes/294-enh_delete_copy.rst
+++ b/docs/source/upcoming_release_notes/294-enh_delete_copy.rst
@@ -1,0 +1,22 @@
+294 enh_delete_copy
+###################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- adds delete cli command
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -291,6 +291,18 @@ def add(ctx, clone: str):
 @happi_cli.command()
 @click.argument('name', type=str)
 @click.pass_context
+def copy(ctx, name):
+    """
+    Copy the item NAME.
+
+    Simply wraps ``happi add --clone``
+    """
+    ctx.invoke(add, clone=name)
+
+
+@happi_cli.command()
+@click.argument('name', type=str)
+@click.pass_context
 def delete(ctx, name: str):
     """
     Delete an existing entry.  Only accepts exact names
@@ -302,7 +314,9 @@ def delete(ctx, name: str):
         raise click.ClickException(f'Could not find item ({name}): {e}')
 
     item.show_info()
-    if click.confirm('Are you sure you want to delete this entry?'):
+    if click.confirm('Are you sure you want to delete this entry? \n'
+                     'Remember you can mark an entry as inactive with \n'
+                     '"happi edit my_device_name active=false"'):
         logger.info('Deleting item')
         client.remove_item(item)
         click.echo(f'Entry {name} removed')

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -237,7 +237,7 @@ def search_parser(
               'Provide the name of the item to clone.')
 @click.pass_context
 def add(ctx, clone: str):
-    """Add new entries interactively."""
+    """Add new entries interactively. Copy entries with --clone."""
     logger.debug(f'Starting interactive add, {clone}')
     # retrieve client
     client = ctx.obj
@@ -284,6 +284,28 @@ def add(ctx, clone: str):
     if click.confirm('Please confirm the item info is correct'):
         logger.info('Adding item')
         item.save()
+    else:
+        logger.info('Aborting')
+
+
+@happi_cli.command()
+@click.argument('name', type=str)
+@click.pass_context
+def delete(ctx, name: str):
+    """
+    Delete an existing entry.  Only accepts exact names
+    """
+    client = ctx.obj
+    try:
+        item = client.find_item(name=name)
+    except SearchError as e:
+        raise click.ClickException(f'Could not find item ({name}): {e}')
+
+    item.show_info()
+    if click.confirm('Are you sure you want to delete this entry?'):
+        logger.info('Deleting item')
+        client.remove_item(item)
+        click.echo(f'Entry {name} removed')
     else:
         logger.info('Aborting')
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -237,7 +237,7 @@ def search_parser(
               'Provide the name of the item to clone.')
 @click.pass_context
 def add(ctx, clone: str):
-    """Add new entries interactively. Copy entries with --clone."""
+    """Add new entries or copy existing entries."""
     logger.debug(f'Starting interactive add, {clone}')
     # retrieve client
     client = ctx.obj
@@ -375,7 +375,7 @@ def edit(ctx, name: str, edits: List[str]):
 @click.argument('item_names', nargs=-1)
 @click.pass_context
 def load(ctx, item_names: List[str]):
-    """Open IPython terminal with ITEM_NAMES loaded"""
+    """Open IPython terminal with ITEM_NAMES loaded."""
 
     logger.debug('Starting load block')
     # retrieve client
@@ -406,13 +406,13 @@ def load(ctx, item_names: List[str]):
         shell.interact()
 
 
-# TODO: FIgure out how to deal with json and click.  list of args doesn't
+# TODO: Figure out how to deal with json and click.  list of args doesn't
 # translate exactly
 @happi_cli.command()
 @click.argument("json_data", nargs=-1)
 @click.pass_context
 def update(ctx, json_data: str):
-    """Update happi db with JSON_DATA payload"""
+    """Update happi db with JSON_DATA payload."""
     # retrieve client
     client = ctx.obj
     if len(json_data) < 1:

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -408,8 +408,8 @@ def db(tmp_path):
     json_path = tmp_path / 'db.json'
     json_path.write_text("""\
 {
-    "TST_BASE_PIM": {
-        "_id": "TST_BASE_PIM",
+    "tst_base_pim": {
+        "_id": "tst_base_pim",
         "active": true,
         "beamline": "TST",
         "creation": "Tue Jan 29 09:46:00 2019",
@@ -426,8 +426,8 @@ def db(tmp_path):
         "z": 3.0,
         "y": 40.0
     },
-    "TST_BASE_PIM2": {
-        "_id": "TST_BASE_PIM2",
+    "tst_base_pim2": {
+        "_id": "tst_base_pim2",
         "active": true,
         "args": [
             "{{prefix}}"

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -373,6 +373,24 @@ def test_add_cli(
     assert_match_expected(result, expected_output, expected_return)
 
 
+def test_delete_cli(
+    happi_cfg: str,
+    runner: CliRunner
+):
+    delete_result = runner.invoke(
+        happi_cli,
+        ['--path', happi_cfg, 'delete', 'tst_base_pim'],
+        input='y\n'
+    )
+    assert delete_result.exit_code == 0
+
+    # confirm item is gone
+    search_result = runner.invoke(
+        happi_cli, ['--path', happi_cfg, 'search', 'tst_base_pim']
+    )
+    assert_in_expected(search_result, 'No items found', 0)
+
+
 @pytest.mark.parametrize("from_user, expected_output", [
     # Test add --clone item - succeeding
     pytest.param('\n'.join(['happi_new_name', 'device_class',

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -566,7 +566,7 @@ def test_load(
 
 def test_update(happi_cfg: str, runner: CliRunner):
     new = """[ {
-        "_id": "TST_BASE_PIM2",
+        "_id": "tst_base_pim2",
         "active": true,
         "args": [
             "{{prefix}}"


### PR DESCRIPTION
## Description
Adds a delete cli command.  Touches up some of the `add --clone` documentation to hopefully make it more obvious you can copy items. 

Modified existing test db to have `_id` match `name`, because happi was getting confused.  (happi client assumes `_id_key = name`)

## Motivation and Context
I was asked about this twice in one week, meaning it was time to make it easier for people

closes #293 

## How Has This Been Tested?
Added a delete test.  Looked at the `happi -h` output

## Where Has This Been Documented?
This PR, docstrings 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (Travis CI)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
