### PR TITLE
ENH: add audit functions - arg/kwarg information verification and wait for connection

### DIFF
--- a/docs/source/upcoming_release_notes/295-enh_audit_fns.rst
+++ b/docs/source/upcoming_release_notes/295-enh_audit_fns.rst
@@ -1,0 +1,26 @@
+295 enh_audit_fns
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- adds audit functions that check the connection status of all signals in an
+  ophyd device (``check_wait_connection``) and verify any fields requested by
+  args/kwargs exist in the database (``check_args_kwargs_match``).
+- adds ``happi audit -d/--details`` option to print the source of a requested
+  audit function
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/audit.py
+++ b/happi/audit.py
@@ -69,6 +69,11 @@ def check_wait_connection(result: SearchResult) -> None:
     """
     dev = result.get()
 
+    assert (hasattr(dev, 'wait_for_connection') and
+            callable(getattr(dev, 'wait_for_connection'))), \
+           ('device has no wait_for_connection method, and is likely '
+            'not an ophyd device')
+
     try:
         dev.wait_for_connection(timeout=5)
     except TimeoutError as te:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1042,6 +1042,7 @@ def audit(
         json.dump(final_dict, indent=2, fp=sys.stdout)
     else:
         pt = prettytable.PrettyTable(field_names=['name', 'check', 'error'])
+        pt.align['error'] = 'l'
         last_name = ''
         for name, success, check, msg in zip(test_results['name'],
                                              test_results['success'],

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -931,6 +931,8 @@ def pyepics_cleanup():
 @click.option('-c', '--check', 'check_choices', multiple=True, default=[],
               help='Name of the check to include.  '
                    'Can also provide a substring')
+@click.option('-d', '--details', 'details',
+              help='Show the details of the specified audit function(s)')
 @click.option('--glob/--regex', 'use_glob', default=True,
               help='Use glob style (default) or regex style search terms. '
               r'Regex requires backslashes to be escaped (eg. at\\d.\\d)')
@@ -944,6 +946,7 @@ def audit(
     list_checks: bool,
     ext_file: Optional[str],
     check_choices: List[str],
+    details: str,
     use_glob: bool,
     names_only: bool,
     show_json: bool,
@@ -980,6 +983,13 @@ def audit(
         for chk in checks:
             check_pt.add_row([chk.__name__, inspect.cleandoc(chk.__doc__)])
         print(check_pt)
+        return
+
+    if details:
+        check_fns = [fn for fn in checks if details in fn.__name__]
+        for fn in check_fns:
+            click.echo(inspect.getsource(fn))
+
         return
 
     # gather selected checks

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -498,6 +498,25 @@ def bad_db(tmp_path):
         "last_edit": "Thu Apr 12 14:40:08 2018",
         "name": "tst_extra_info",
         "type": "HappiItem"
+    },
+    "tst_arg_mismatch": {
+        "_id": "tst_arg_mismatch",
+        "args": ["{{active}}"],
+        "creation": "Tue Jan 29 09:46:00 2019",
+        "device_class": "types.SimpleNamespace",
+        "last_edit": "Thu Apr 12 14:40:08 2018",
+        "name": "tst_arg_mismatch",
+        "type": "HappiItem"
+    },
+    "tst_kwarg_mismatch": {
+        "_id": "tst_kwarg_mismatch",
+        "active": true,
+        "args": ["{{active}}"],
+        "device_class": "types.SimpleNamespace",
+        "kwargs": {"creation": "{{creation}}"},
+        "name": "tst_kwarg_mismatch",
+        "last_edit": "Thu Apr 12 14:40:08 2018",
+        "type": "HappiItem"
     }
 }
 """)

--- a/happi/tests/test_audit.py
+++ b/happi/tests/test_audit.py
@@ -24,8 +24,9 @@ def number_failed_devices(output: str):
 
 @pytest.mark.parametrize("n_fails, check", [
    (1, "check_name_match_id"),
-   (1, "check_instantiation"),
-   (1, "check_extra_info")
+   (3, "check_instantiation"),  # simplenamespace does not take args
+   (1, "check_extra_info"),
+   (2, "check_args_kwargs_match")
    ]
 )
 def test_audit_cli(


### PR DESCRIPTION
## Description
Adds additional audit functions for:
* ensuring any jinja-filled args or kwargs have corresponding entries
* checking that all signals in a device are connected

## Motivation and Context
These got prototyped during some debugging and I figured it was a good time to push this forward

The args and kwargs test needs to pull the document from the client directly, since when a HappiItem is created, any fields that exist on the container but not in the document are filled with `None`

closes #290 

## How Has This Been Tested?
A test case for the args/kwargs audit has been added.  (this took the bulk of the time, the tests were finicky)

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (Travis CI)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
