### PR TITLE
ENH: `happi repair`

### DIFF
--- a/docs/source/upcoming_release_notes/300-enh_repair.rst
+++ b/docs/source/upcoming_release_notes/300-enh_repair.rst
@@ -1,0 +1,22 @@
+300 enh_repair
+##############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds ``happi repair`` command, for synchronizing backend database with fields expected by container.  Adds a corresponding audit function
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/audit.py
+++ b/happi/audit.py
@@ -58,7 +58,8 @@ def check_name_match_id(result: SearchResult) -> None:
     """
     id_field = result.metadata.get('_id')
     name_field = result.metadata.get('name')
-    assert id_field == name_field, f'id: {id_field} != name: {name_field}'
+    if id_field != name_field:
+        raise ValueError(f'id: {id_field} != name: {name_field}')
 
 
 def check_wait_connection(result: SearchResult) -> None:
@@ -69,10 +70,10 @@ def check_wait_connection(result: SearchResult) -> None:
     """
     dev = result.get()
 
-    assert (hasattr(dev, 'wait_for_connection') and
-            callable(getattr(dev, 'wait_for_connection'))), \
-           ('device has no wait_for_connection method, and is likely '
-            'not an ophyd v1 device')
+    if not (hasattr(dev, 'wait_for_connection') and
+            callable(getattr(dev, 'wait_for_connection'))):
+        raise ValueError('device has no wait_for_connection method, '
+                         'and is likely not an ophyd v1 device')
 
     try:
         dev.wait_for_connection(timeout=5)
@@ -105,8 +106,8 @@ def check_args_kwargs_match(result: SearchResult) -> None:
     rendered = template.render(**doc)
     undefined = meta.find_undeclared_variables(env.parse(rendered))
 
-    assert len(undefined) == 0, \
-           f'undefined variables found in document: {undefined}'
+    if len(undefined) != 0:
+        raise ValueError(f'undefined variables found in document: {undefined}')
 
 
 def find_unfilled_mandatory_info(
@@ -141,8 +142,8 @@ def check_unfilled_mandatory_info(result: SearchResult) -> None:
     This may arise from manual editing of the backend database.
     """
     unfilled_info = find_unfilled_mandatory_info(result)
-    assert len(unfilled_info) == 0, \
-           f'unfilled mandatory information found: {unfilled_info}'
+    if len(unfilled_info) != 0:
+        raise ValueError(f'unfilled mandatory information found: {unfilled_info}')
 
 
 def verify_result(

--- a/happi/audit.py
+++ b/happi/audit.py
@@ -119,6 +119,19 @@ def find_unfilled_mandatory_info(
             if getattr(result.item, info) is None]
 
 
+def find_unfilled_optional_info(
+    result: SearchResult
+) -> list[str]:
+    """
+    Return all optional fields that are missing a value
+    """
+    # cannot getattr for extraneous info, shortcircuit conditional
+    return [info for info in list(result.item.keys())
+            if info not in result.item.mandatory_info
+            and info not in result.item.extraneous.keys()
+            and getattr(result.item, info) is None]
+
+
 def check_unfilled_mandatory_info(result: SearchResult) -> None:
     """
     Check that all mandatory EntryInfo have a value.

--- a/happi/audit.py
+++ b/happi/audit.py
@@ -109,6 +109,29 @@ def check_args_kwargs_match(result: SearchResult) -> None:
            f'undefined variables found in document: {undefined}'
 
 
+def find_unfilled_mandatory_info(
+    result: SearchResult
+) -> list[str]:
+    """
+    Return all mandatory fields that are missing a value
+    """
+    return [info for info in result.item.mandatory_info
+            if getattr(result.item, info) is None]
+
+
+def check_unfilled_mandatory_info(result: SearchResult) -> None:
+    """
+    Check that all mandatory EntryInfo have a value.
+
+    This identifies problems originating from a mismatch between
+    an item's backend representation and desired container.
+    This may arise from manual editing of the backend database.
+    """
+    unfilled_info = find_unfilled_mandatory_info(result)
+    assert len(unfilled_info) == 0, \
+           f'unfilled mandatory information found: {unfilled_info}'
+
+
 def verify_result(
     result: SearchResult,
     check: Callable[[SearchResult], None]
@@ -150,4 +173,5 @@ def verify_result(
 
 
 checks = [check_instantiation, check_extra_info, check_name_match_id,
-          check_wait_connection, check_args_kwargs_match]
+          check_wait_connection, check_args_kwargs_match,
+          check_unfilled_mandatory_info]

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1079,7 +1079,7 @@ def audit(
 
 @happi_cli.command()
 @click.pass_context
-@click.option('--fix-optional/--ignore-optinal', 'fix_optional', default=False,
+@click.option('--fix-optional/--ignore-optional', 'fix_optional', default=False,
               help='Also prompt for user input on optional information')
 @click.option('--glob/--regex', 'use_glob', default=True,
               help='Use glob (default) or regex style search terms. '
@@ -1139,7 +1139,7 @@ def repair(
             res.item.save()
         except KeyboardInterrupt:
             # Finish the current save if interrupted
-            logger.warning('caught keboard interrupt, finishing')
+            logger.warning('caught keyboard interrupt, finishing')
             res.item.save()
             break
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1114,11 +1114,9 @@ def repair(
         logger.debug(f'repairing ({res_name})')
         while req_field:
             if getattr(res.item, req_field) is None:
-                default = res.item._info_attrs[req_field].default
                 req_value = click.prompt(
                     f'Required value for ({res_name}.{req_field}) '
-                    'missing, please provide new value',
-                    default=default
+                    'missing, please provide new value'
                 )
                 try:
                     setattr(res.item, req_field, req_value)

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -517,6 +517,17 @@ def bad_db(tmp_path):
         "name": "tst_kwarg_mismatch",
         "last_edit": "Thu Apr 12 14:40:08 2018",
         "type": "HappiItem"
+    },
+    "tst_missing_mandatory": {
+        "_id": "tst_missing_mandatory",
+        "active": true,
+        "args": ["{{active}}"],
+        "creation": "Tue Jan 29 09:46:00 2019",
+        "device_class": "types.SimpleNamespace",
+        "kwargs": {"creation": "{{creation}}"},
+        "name": "tst_missing_mandatory",
+        "last_edit": "Thu Apr 12 14:40:08 2018",
+        "type": "OphydItem"
     }
 }
 """)

--- a/happi/tests/test_audit.py
+++ b/happi/tests/test_audit.py
@@ -24,9 +24,10 @@ def number_failed_devices(output: str):
 
 @pytest.mark.parametrize("n_fails, check", [
     (1, "check_name_match_id"),
-    (3, "check_instantiation"),  # simplenamespace does not take args
+    (4, "check_instantiation"),  # simplenamespace does not take args
     (1, "check_extra_info"),
-    (2, "check_args_kwargs_match")
+    (2, "check_args_kwargs_match"),
+    (1, "check_unfilled_mandatory_info")
 ])
 def test_audit_cli(
     runner: CliRunner,


### PR DESCRIPTION
## Description
Adds the `happi repair` command, which (currently) aims to update the database to align with the information expected by the container

Some attempts are made to cancel the saving process safely, as well as prompt the user for missing information

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#297 , where initial search failures were tracked down 

A short list of cases I tried to cover / thought about:
|                      | Mandatory             | Optional                |
|----------------------|-----------------------|-------------------------|
| Missing, has default | not possible       | fill with default value |
| Missing, no default  | prompt                | fill with 'null'        |

Currently if you run the audit and there are no mandatory items with missing data, the procedure will just re-save the item.  I wanted to only save if there was a change made, but couldn't find a clean way to determine if this was the case without manipulating the backend data directly.  

## How Has This Been Tested?
Interactively, though I should probably write tests.

## Where Has This Been Documented?
This PR, docstrings incoming

<img width="770" alt="image" src="https://user-images.githubusercontent.com/35379409/220491339-4dc19bc7-3828-4b61-9b1f-42c77e4f985c.png">

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on continuous integration (GHA)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
