### PR TITLE
BLD: set content type for readme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ namespaces = false
 
 [tool.setuptools.dynamic.readme]
 file = "README.md"
+content-type = "text/markdown"
 
 [tool.setuptools.dynamic.dependencies]
 file = [ "requirements.txt",]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* PyPI uploads broken since content type not set on long description (README)
* This sets the content type

## Motivation and Context
PyPI release day

Ref: https://github.com/pcdshub/pcds-python-migration-tools/issues/17

## How Has This Been Tested?
Fingers crossing
