### PR TITLE
CI: inherit secrets

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   standard:
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@master
+    secrets: inherit
     with:
       # The workflow needs to know the package name.  This can be determined
       # automatically if the repository name is the same as the import name.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Inherit secrets so we can publish to PyPI in our GHA CI workflow
