### PR TITLE
ENH: add post-md-set hook to loader

### DIFF
--- a/docs/source/upcoming_release_notes/308-enh_post_md-hook.rst
+++ b/docs/source/upcoming_release_notes/308-enh_post_md-hook.rst
@@ -1,0 +1,22 @@
+308 enh_post_md-hook
+###################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds a hook in happi.loader.from_container that runs the method ``post_happi_md`` on an instantiated object after the metadata container has been attached.  This allows a clear method for objects to interact with happi metadata if desired.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -91,6 +91,7 @@ def fill_template(
 def from_container(
     item: HappiItem,
     attach_md: bool = True,
+    run_post_attach_hook: bool = True,
     use_cache: bool = True,
     threaded: bool = False,
 ) -> Any:
@@ -200,6 +201,12 @@ def from_container(
             setattr(obj, 'md', item)
         except Exception:
             logger.warning("Unable to attach metadata dictionary to device")
+
+        if run_post_attach_hook and hasattr(obj, 'post_happi_md'):
+            try:
+                obj.post_happi_md()
+            except Exception as ex:
+                logger.warning(f"Unable to run {obj}.post_happi_md: {ex}")
 
     # Store the device in the cache
     cache[item.name] = obj

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -123,6 +123,9 @@ def from_container(
         The item to load.
     attach_md : bool, optional
         Attach the container to the instantiated object as ``md``.
+    run_post_attach_hook : bool, optional
+        Run ``post_happi_md`` method on the device after attaching the container
+        if possible.
     use_cache : bool, optional
         When devices are loaded they are stored in the ``happi.cache``
         dictionary. This means that repeated attempts to load the device will

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -149,3 +150,28 @@ def test_filter_kwargs(item_jinja: OphydItem):
     assert getattr(filtered_dev, 'blank_exclude', 'DNE') == 'DNE'
     for bl in blanks:
         assert getattr(filtered_dev, bl, 'DNE') == 'DNE'
+
+
+class PostDevice:
+    def post_happi_md(self):
+        print('post_happi_md hook run')
+
+
+@pytest.fixture
+def item_post_md_hook():
+    item = HappiItem(name='post_test',
+                     device_class='happi.tests.test_loader.PostDevice')
+    return item
+
+
+def test_post_happi_md(item_post_md_hook: HappiItem):
+    with patch('happi.tests.test_loader.PostDevice.post_happi_md') as mock:
+        dev = from_container(item_post_md_hook, use_cache=False)
+        assert isinstance(dev, PostDevice)
+        mock.assert_called_once()
+
+    with patch('happi.tests.test_loader.PostDevice.post_happi_md') as mock:
+        dev = from_container(item_post_md_hook, run_post_attach_hook=False,
+                             use_cache=False)
+        assert isinstance(dev, PostDevice)
+        mock.assert_not_called()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a hook to allow code to be run on the object after the `.md` attribute is set.  This would allow the loaded object to interact with its metadata. 

## Motivation and Context
Most recently https://github.com/pcdshub/pcdsdevices/pull/1132/, but also the lightpath input/output branches setting in pcdsdevices previously [(link)](https://github.com/pcdshub/pcdsdevices/blob/02b295e236a21b4d8fcdc6969041f5b8a3b5fa03/pcdsdevices/interface.py#L1787)

Previously, we've hooked the `.md` setter to do some operations after happi attempts to set  the `.md` attribute.  This has caused (me) confusion, and unless thoroughly annotated the purpose of the setter is not clear (mostly to me with  my goldfish memory)

## How Has This Been Tested?
Added a quick test 

## Where Has This Been Documented?
Here, and pre-release notes eventually

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
