### PR TITLE
DOC: fix old typo in parameters

### DIFF
--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -44,7 +44,7 @@ class JSONBackend(_Backend):
     ----------
     path : str
         Path to JSON file.
-    initialze : bool, optional
+    initialize : bool, optional
         Initialize a new empty JSON file to begin filling.
     cfg_path : str, optional
         Path to the happi config.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix a 6-year-old typo in this docstring.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The docstrings are used to build the deployed docs, and typos in parameters can be especially confusing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
I'll do the documentation step later I just want to get the edit in now before I forget
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
