### PR TITLE
GUI/MNT: let HappiDeviceTreeView include items where key is not found

### DIFF
--- a/docs/source/upcoming_release_notes/310-mnt_missing_key.rst
+++ b/docs/source/upcoming_release_notes/310-mnt_missing_key.rst
@@ -1,0 +1,22 @@
+310 mnt_missing_key
+###################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Makes HappiDeviceTreeView more tolerant of items with missing metadata keys. items missing the key used to group the tree view will be organized into a catch-all "[KEY NOT FOUND]" group
+
+Contributors
+------------
+- tangkong

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -170,10 +170,12 @@ class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
                 field_val = get_happi_entry_value(entry.item, field)
                 entry_group[field_val].append(entry.item)
             except ValueError:
-                logger.exception(
+                logger.debug(
                     'Could not retrieve value for field %s at entry %s',
                     field, entry
                 )
+                field_val = '[KEY NOT FOUND]'
+                entry_group[field_val].append(entry.item)
 
         for idx, (key_value, entries) in enumerate(entry_group.items()):
             root = QtGui.QStandardItem(key_value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Instead of omitting items, show them under a catch-all tree item "[KEY NOT FOUND]"

## Motivation and Context
If you're looking to group items by a metadata key, I think you'd expect every item in the database to be represented.  If you were to group the database by a field and then search for an item, it might just not exist if its metadata didn't feature that field.

In reality this was inspired by the logger spam when switching between views.  Currently ATEF is the only real user of this model view, I think this is a better way to handle missing metadata.  

Sidebar: I considered modifying `get_happi_entry_value` to pass null/None values from the database through, but in the end this can be grouped together with missing keys without loss of information.  I do think raising a ValueError there is a bit overkill, since happi containers missing a key is a bit overkill.  In the end this is the smallest change that solves my current problem.

## How Has This Been Tested?
interactively, primarily using the ATEF Happi viewer.

## Where Has This Been Documented?
This PR

old: (item disappears when grouped)
<img width="309" alt="image" src="https://user-images.githubusercontent.com/35379409/235739685-50b46a3d-af5f-426d-aefc-8a59223f0efe.png">


new: 
<img width="302" alt="image" src="https://user-images.githubusercontent.com/35379409/235739430-38f66621-afb9-4a8c-a430-0aebeea2f743.png">


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
