### PR TITLE
ENH: add new cli command edit-config

### DIFF
--- a/docs/source/upcoming_release_notes/313-new_cli_command_edit-config.rst
+++ b/docs/source/upcoming_release_notes/313-new_cli_command_edit-config.rst
@@ -1,0 +1,22 @@
+313 new cli command edit-config
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- new CLI command edit-config, opens happi configuration file for quick editing
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- untzag

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -14,6 +14,7 @@ import logging
 import os
 # on import allows arrow key navigation in prompt
 import readline  # noqa
+import subprocess
 import sys
 import time
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
@@ -1131,6 +1132,17 @@ def repair(
             logger.warning('caught keyboard interrupt, finishing')
             res.item.save()
             break
+
+
+@happi_cli.command()
+def edit_config():
+    config_filepath = happi.client.Client.find_config()
+    if sys.platform.startswith("win32"):
+        import shutil
+        editor = shutil.which(os.environ.get("EDITOR", "notepad.exe"))
+        subprocess.run([editor, config_filepath])
+    else:
+        subprocess.run([os.environ.get("EDITOR", "vi"), config_filepath])
 
 
 def main():

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1136,6 +1136,7 @@ def repair(
 
 @happi_cli.command()
 def edit_config():
+    """Open happi configuration file for editing."""
     config_filepath = happi.client.Client.find_config()
     if sys.platform.startswith("win32"):
         import shutil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Adds new command-line syntax `happi edit-config`, which opens the config file in `$EDITOR`. This way people don't have to remember or care where the config file is. On Windows falls back to notepad, elsewise vi. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In conjunction with #312, I'm trying to make happi more end-user friendly, especially on Windows and non-managed machines. I personally like this pattern and yaq users are used to "... edit-config".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Works on my machine :smile:. If y'all want tests let me know.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Click's magic means it shows up under `happi --help`

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
