### PR TITLE
ENH: new cli command init

### DIFF
--- a/docs/source/upcoming_release_notes/314-new_cli_command_init.rst
+++ b/docs/source/upcoming_release_notes/314-new_cli_command_init.rst
@@ -1,0 +1,22 @@
+314 new cli command init
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- New CLI command "init" designed to initialize config and point to empty database. Useful for installing happi on new machines.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- untzag

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1187,6 +1187,7 @@ def init(overwrite):
 
     click.echo("Done!")
 
+
 def main():
     """Execute the ``happi_cli`` with command line arguments"""
     happi_cli()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Add a new CLI command `happi init`. This command creates a new config file in the default place pointing to an empty json database in the default place.

If an existing config file is found `happi init` will refuse to overwrite it unless you use the (hopefully scary) incantation `happi init --overwrite`.

Command tells you where the config and database files are being put.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Intent is to make it easy for users to "bootstrap" brand new happi installs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CLI, works on my machine.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

CLI is auto-documented.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
