### PR TITLE
ENH: happi config cli sub-commands

### DIFF
--- a/docs/source/upcoming_release_notes/315-happi_config_cli_sub-commands.rst
+++ b/docs/source/upcoming_release_notes/315-happi_config_cli_sub-commands.rst
@@ -7,9 +7,9 @@ API Changes
 
 Features
 --------
-- happi config edit - open config file in $EDITOR
-- happi config init - create new config file with default options
-- happi config show - show location & contents of config file
+- CLI command ``happi config edit`` - open config file in $EDITOR
+- CLI command ``happi config init`` - create new config file with default options
+- CLI command ``happi config show`` - show location & contents of config file
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/315-happi_config_cli_sub-commands.rst
+++ b/docs/source/upcoming_release_notes/315-happi_config_cli_sub-commands.rst
@@ -1,0 +1,24 @@
+315 happi config cli sub-commands
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- happi config edit - open config file in $EDITOR
+- happi config init - create new config file with default options
+- happi config show - show location & contents of config file
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- untzag

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -402,7 +402,7 @@ def load(ctx, item_names: list[str]):
 
     logger.debug('Starting load block')
     # retrieve client
-    client = ctx.obj
+    client = get_happi_client_from_config(ctx.obj)
 
     devices = {}
     names = " ".join(item_names)
@@ -1209,9 +1209,9 @@ def show():
 
     def draw_line():
         try:
-             click.echo("-"*os.get_terminal_size()[0])
+            click.echo("-"*os.get_terminal_size()[0])
         except OSError:
-             # non-interactive mode (piping results). No max width
+            # non-interactive mode (piping results). No max width
             click.echo("-"*79)
 
     draw_line()

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1163,13 +1163,14 @@ def init(overwrite):
     # find config_filepath
     try:
         config_filepath = Path(happi.client.Client.find_config())
+    except OSError:
+        config_filepath = Path(platformdirs.user_config_dir("happi")) / "happi.cfg"
+    else:
         if not overwrite:
             click.echo("Found existing config file at:")
             click.echo(f"  {config_filepath}")
             click.echo("Stopping! Use --overwrite to destroy this config file.")
             return
-    except OSError:
-        config_filepath = Path(platformdirs.user_config_dir("happi")) / "happi.cfg"
     click.echo("Creating new config file at:")
     click.echo(f"  {config_filepath}")
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1157,7 +1157,8 @@ def edit_config():
 @config.command()
 @click.option("--overwrite/--no-overwrite", "overwrite", default=False,
               help="Overwrite existing config.")
-def init(overwrite):
+@click.option("--backend", type=click.Choice(["json"], case_sensitive=False), default="json")
+def init(overwrite, backend):
     """Create configuration file with default options."""
 
     # find config_filepath

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -40,6 +40,19 @@ version_msg = f'Happi: Version {happi.__version__} from {happi.__file__}'
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
+def get_happi_client_from_config(path):
+    # gather client
+    try:
+        client = happi.client.Client.from_config(path)
+        logger.debug("Happi client: %r" % client)
+        # insert items into context to be passed to subcommands
+        # User objects must be assigned to ctx.obj, which will be passed
+        # through to new context objects
+        return client
+    except OSError:
+        logger.debug("Happi configuration not found.")
+
+
 @click.group(
     help=('The happi command-line interface, used to view and manipulate '
           'device databases'),
@@ -66,16 +79,7 @@ def happi_cli(ctx, path, verbose):
                         fmt='[%(asctime)s] - %(levelname)s -  %(message)s')
     logger.debug("Set logging level of %r to %r", shown_logger.name, level)
 
-    # gather client
-    try:
-        client = happi.client.Client.from_config(cfg=path)
-        logger.debug("Happi client: %r" % client)
-        # insert items into context to be passed to subcommands
-        # User objects must be assigned to ctx.obj, which will be passed
-        # through to new context objects
-        ctx.obj = client
-    except OSError:
-        logger.debug("Happi configuration not found.")
+    ctx.obj = path
 
     # Cleanup tasks related to loaded devices
     @ctx.call_on_close
@@ -110,7 +114,7 @@ def search(
     logger.debug("We're in the search block")
 
     final_results = search_parser(
-        client=ctx.obj,
+        client=get_happi_client_from_config(ctx.obj),
         use_glob=use_glob,
         search_criteria=search_criteria,
     )
@@ -245,7 +249,7 @@ def add(ctx, clone: str):
     """Add new entries or copy existing entries."""
     logger.debug(f'Starting interactive add, {clone}')
     # retrieve client
-    client = ctx.obj
+    client = get_happi_client_from_config(ctx.obj)
 
     registry = happi.containers.registry
     if clone:
@@ -312,7 +316,7 @@ def delete(ctx, name: str):
     """
     Delete an existing entry.  Only accepts exact names
     """
-    client = ctx.obj
+    client = get_happi_client_from_config(ctx.obj)
     try:
         item = client.find_item(name=name)
     except SearchError as e:
@@ -340,7 +344,7 @@ def edit(ctx, name: str, edits: list[str]):
     Applies EDITS of the form: field=value to the item of name NAME.
     """
     # retrieve client
-    client = ctx.obj
+    client = get_happi_client_from_config(ctx.obj)
 
     logger.debug('Starting edit block')
     try:
@@ -433,7 +437,7 @@ def load(ctx, item_names: list[str]):
 def update(ctx, json_data: str):
     """Update happi db with JSON_DATA payload."""
     # retrieve client
-    client = ctx.obj
+    client = get_happi_client_from_config(ctx.obj)
     if len(json_data) < 1:
         raise click.BadArgumentUsage('No json data given')
 
@@ -476,7 +480,7 @@ def transfer(ctx, name: str, target: str):
     """
     logger.debug('Starting transfer block')
     # retrive client
-    client = ctx.obj
+    client = get_happi_client_from_config(ctx.obj)
     # verify name and target both exist and are valid
     try:
         item = client.find_item(name=name)
@@ -550,7 +554,7 @@ def benchmark(
     cli function. A blank search term means to load all the devices.
     """
     logger.debug('Starting benchmark block')
-    client: happi.Client = ctx.obj
+    client: happi.Client = get_happi_client_from_config(ctx.obj)
     full_stats = []
     logger.info('Collecting happi items...')
     start = time.monotonic()
@@ -740,7 +744,7 @@ def profile(
     logger.debug('Starting profile block')
     if profiler not in ('auto', 'pcdsutils', 'cprofile'):
         raise RuntimeError(f'Invalid profiler selection {profiler}')
-    client: happi.Client = ctx.obj
+    client: happi.Client = get_happi_client_from_config(ctx.obj)
     if profile_all:
         profile_database = True
         profile_import = True
@@ -1011,7 +1015,7 @@ def audit(
         # take all checks
         check_list = checks
 
-    client: happi.Client = ctx.obj
+    client: happi.Client = get_happi_client_from_config(ctx.obj)
 
     results = search_parser(client, use_glob, search_criteria)
     logger.info(f'found {len(results)} items to verify')
@@ -1101,7 +1105,7 @@ def repair(
     """
     logger.debug('starting repair block')
 
-    client: happi.Client = ctx.obj
+    client: happi.Client = get_happi_client_from_config(ctx.obj)
     if search_criteria:
         results = search_parser(client, use_glob, search_criteria)
     else:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1202,11 +1202,19 @@ def show():
     """Show configuration file in current state."""
     config_filepath = Path(happi.client.Client.find_config())
     click.echo(f"File: {config_filepath}")
-    click.echo("-"*79)
+
+    def draw_line():
+        try:
+             click.echo("-"*os.get_terminal_size()[0])
+        except OSError:
+             # non-interactive mode (piping results). No max width
+            click.echo("-"*79)
+
+    draw_line()
     with open(config_filepath, "r") as f:
         for line in f:
             click.echo(line.strip())
-    click.echo("-"*79)
+    draw_line()
 
 
 def main():

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -97,10 +97,10 @@ def test_cli_no_argument(runner: CliRunner):
     assert 'Commands:' in result.output
 
 
-def test_search(client: happi.client.Client):
+def test_search(client: happi.client.Client, happi_cfg: str):
     res = client.search_regex(beamline="TST")
 
-    with search.make_context('search', ['beamline=TST'], obj=client) as ctx:
+    with search.make_context('search', ['beamline=TST'], obj=happi_cfg) as ctx:
         res_cli = search.invoke(ctx)
 
     assert [r.item for r in res] == [r.item for r in res_cli]
@@ -113,7 +113,7 @@ def test_search_with_name(
 ):
     res = client.search_regex(name='TST_BASE_PIM2')
 
-    with search.make_context('search', ['TST_BASE_PIM2'], obj=client) as ctx:
+    with search.make_context('search', ['TST_BASE_PIM2'], obj=happi_cfg) as ctx:
         res_cli = search.invoke(ctx)
 
     assert [r.item for r in res] == [r.item for r in res_cli]
@@ -136,9 +136,9 @@ def test_search_glob_regex(runner: CliRunner, happi_cfg: str):
     assert glob_result.output == regex_result.output
 
 
-def test_search_z(client: happi.client.Client):
+def test_search_z(happi_cfg: str, client: happi.client.Client):
     res = client.search_regex(z="6.0")
-    with search.make_context('search', ['z=6.0'], obj=client) as ctx:
+    with search.make_context('search', ['z=6.0'], obj=happi_cfg) as ctx:
         res_cli = search.invoke(ctx)
 
     assert [r.item for r in res] == [r.item for r in res_cli]
@@ -151,7 +151,7 @@ def test_search_z_range(
 ):
     res = client.search_range('z', 3.0, 6.0)
 
-    with search.make_context('search', ['z=3.0,6.0'], obj=client) as ctx:
+    with search.make_context('search', ['z=3.0,6.0'], obj=happi_cfg) as ctx:
         res_cli = search.invoke(ctx)
 
     assert [r.item for r in res] == [r.item for r in res_cli]
@@ -208,13 +208,13 @@ def test_search_int_float(runner: CliRunner, happi_cfg: str):
     # assert float_result.output == ''
 
 
-def test_both_range_and_regex_search(client: happi.client.Client):
+def test_both_range_and_regex_search(happi_cfg: str, client: happi.client.Client):
     # we're only interested in getting this entry (TST_BASE_PIM2)
     res = client.search_regex(z='6.0')
     # we're going to search for z=3,7 name=TST_BASE_PIM2
     # we should only get in return one entry, even though the z value found 2
     with search.make_context('search', ['name=TST_BASE_PIM2', 'z=3.0,7.0'],
-                             obj=client) as ctx:
+                             obj=happi_cfg) as ctx:
         res_cli = search.invoke(ctx)
 
     assert [r.item for r in res] == [r.item for r in res_cli]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include_package_data = true
 file = "LICENSE.md"
 
 [project.scripts]
-happi = "happi.cli:happi_cli"
+happi = "happi.cli:main"
 
 [tool.setuptools_scm]
 write_to = "happi/_version.py"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Adding new sub-command-group `config` to CLI.
- `happi config edit` - open config file in $EDITOR
- `happi config init` - create new config file with default options
- `happi config show` - show location & contents of config file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See #314 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my machine.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

CLI is auto-documented.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
