### PR TITLE
MNT/DOC: parse valid json db, improve docstring

### DIFF
--- a/docs/source/upcoming_release_notes/320-bug_update_json.rst
+++ b/docs/source/upcoming_release_notes/320-bug_update_json.rst
@@ -1,0 +1,22 @@
+320 bug_update_json
+###################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Allow `happi update` to handle json-backend-type payloads
+
+Contributors
+------------
+- tangkong

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -438,9 +438,9 @@ def update(ctx, json_data: str):
     """
     Update happi db with JSON_DATA payload.
 
-    To use, either use command substitution to enclose your JSON in quotes:
+    To use, either use command substitution:
 
-        $ happi update "$(cat my.json)"
+        $ happi update $(cat my.json)
 
     Or pipe the JSON payload with `-` as an argument:
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -435,7 +435,38 @@ def load(ctx, item_names: list[str]):
 @click.argument("json_data", nargs=-1)
 @click.pass_context
 def update(ctx, json_data: str):
-    """Update happi db with JSON_DATA payload."""
+    """
+    Update happi db with JSON_DATA payload.
+
+    To use, either use command substitution to enclose your JSON in quotes:
+
+        $ happi update "$(cat my.json)"
+
+    Or pipe the JSON payload with `-` as an argument:
+
+        $ cat my.json | happi update -
+
+    JSON payloads should be a list of items (dictionaries), with at least the
+    "_id" and "type" keys.  eg:
+
+    \b
+        [{
+            "_id": "my_device",
+            <...>
+            "type": "mydevicelibrary.MyDevice"
+        }]
+
+    Or a valid happi json database.  eg:
+
+    \b
+        {
+            "my_device": {
+                "_id": "my_device",
+                <...>
+                "type": "mydevicelibrary.MyDevice"
+            }
+        }
+    """
     # retrieve client
     client = get_happi_client_from_config(ctx.obj)
     if len(json_data) < 1:
@@ -443,12 +474,15 @@ def update(ctx, json_data: str):
 
     # parse input
     input_ = " ".join(json_data).strip()
-    print(json_data)
     if input_ == "-":
         items_input = json.load(sys.stdin)
     else:
         items_input = json.loads(input_)
+
     # insert
+    if isinstance(items_input, dict):
+        items_input = items_input.values()
+
     for item in items_input:
         item = client.create_item(item["type"], **item)
         exists = item["_id"] in [c["_id"] for c in client.all_items]


### PR DESCRIPTION
## Description
* Slightly modifies the `happi update` command to handle json formatted similar to a valid json database.
* Updates the `happi update` docstring (and by proxy help text) to better describe the use case

Now `happi update` can take JSON input that looks like a working json backend: 
<details><summary>Details</summary>
<p>

```
  {
      "al1k2": {
          "_id": "al1k2",
          "active": true,
          "args": [
              "{{prefix}}"
          ],
          <...>
          "type": "pcdsdevices.happi.containers.LCLSItem",
          "z": 778.833
      }
  }
```

</p>
</details> 

or a list of items  in json form (original functionality):
<details><summary>Details</summary>
<p>

```
[{
      "_id": "al1k2",
      "active": true,
      "args": [
          "{{prefix}}"
      ],
      <...>
      "type": "pcdsdevices.happi.containers.LCLSItem",
      "z": 778.833
}]
```

</p>
</details> 

Usage is now described in the subcommand.  One can either pipe input and tell happi to look at stdin:
``` bash
cat my.json | happi update -
```

or use command substitution
``` bash
happi update $(cat my.json)
```

## Motivation and Context
#319 

Click does not inherently read from stdin, we must explicitly tell it to.  If we do this, piping output will work

## How Has This Been Tested?
interactively 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
