### PR TITLE
REF: split out happi audit for programmatic usage

### DIFF
--- a/docs/source/upcoming_release_notes/322-happi-audit-split.rst
+++ b/docs/source/upcoming_release_notes/322-happi-audit-split.rst
@@ -1,0 +1,24 @@
+322 happi-audit-split
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Added ``happi.audit.audit()`` which can be used to programmatically audit
+  happi items.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- The ``happi audit`` CLI entrypoint has been modified to use
+  ``happi.audit.audit()``.
+
+Contributors
+------------
+- klauer

--- a/happi/audit.py
+++ b/happi/audit.py
@@ -219,7 +219,30 @@ def audit(
     redirect: bool = True,
     verbose: bool = False,
     check_list: Optional[CheckList] = None,
+    catch_keyboard_interrupt: bool = True,
 ) -> AuditResults:
+    """
+    Audit the given ``SearchResult`` items.
+
+    Parameters
+    ----------
+    results : list[SearchResult]
+        The search results from the happi client to audit.
+    redirect : bool
+        During the audit process, capture standard output and standard error to
+        avoid connection and error-related spam.
+    verbose : bool
+        Output status messages during the audit process.
+    check_list : list[Check]
+        The callable checks to perform.
+    catch_keyboard_interrupt : bool, optional
+        Catch and record when the user attempts to cancel the audit process.
+
+    Returns
+    -------
+    AuditResults
+        The summarized results of the audit.
+    """
     if check_list is None:
         # If unspecified, use all checks
         check_list = list(checks)
@@ -262,6 +285,8 @@ def audit(
                         test_results["check"].append(check)
                         test_results["msg"].append(msg)
     except KeyboardInterrupt:
+        if not catch_keyboard_interrupt:
+            raise
         if verbose:
             print("Caught KeyboardInterrupt; exiting early...")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Allow for running happi audits programmatically without interfacing with `click`
* Add some more type hints
* Intercept `KeyboardInterrupt` and still show some results in `happi audit` (when you're working from a laptop that has access to zero PVs)

## Motivation and Context
Touching back on auto-generated documentation pages:
* I want to include happi audit information in the Confluence pages for each device and there's no really easy way to do this currently

## How Has This Been Tested?
Test suite and interactively

## Where Has This Been Documented?
This PR 

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
