### PR TITLE
BLD: test line profiler requirements fix / workaround

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,8 +34,6 @@ requirements:
   - psdm_qs_cli >=0.3.1
   - pymongo >=4.0.2
 
-
-
 test:
   commands:
   - happi --help
@@ -44,9 +42,7 @@ test:
   requires:
   - pytest
   - ipython
-  - line_profiler <4.0.0
-
-
+  - line_profiler
 
 about:
   dev_url: https://github.com/pcdshub/happi/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,5 +7,4 @@ pymongo
 mongomock >=3.22.0
 # Removed temporarily, pip installations fail lacking gssapi libs
 # psdm_qs_cli
-# Lineprofiler >=4.0.0 incompatible with happi, but needed for py3.11
-line-profiler <4.0.0
+line-profiler

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -779,6 +779,7 @@ def profile(
     logger.debug('Starting profile block')
     if profiler not in ('auto', 'pcdsutils', 'cprofile'):
         raise RuntimeError(f'Invalid profiler selection {profiler}')
+
     client: happi.Client = get_happi_client_from_config(ctx.obj)
     if profile_all:
         profile_database = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Attempt to use selectors in requirements/conda recipe to let Python 3.11 be special in its line-profiler requirement
* Run profiler test suite on Python 3.9 and 3.10
* Avoid profiler test suite on Python 3.11

## Motivation and Context
* Line profiler is too slow to work with our profiling code
* Line-profiler 4.1.0 is required for Python 3.11 to be functional
* Line profiler < 4 continues to work well for Python 3.9 and 3.10
* We can get Python 3.11 working *and* have Python 3.9, 3.10 still have its profiling tests by way of splitting the requirements into per-version requirements

## How Has This Been Tested?
CI and a bit of local testing / head-scratching

## Where Has This Been Documented?
Entirely in this PR

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
