### PR TITLE
ENH: Match Name to ID Field 

### DIFF
--- a/docs/source/upcoming_release_notes/302-repair_match_name_to_id.rst
+++ b/docs/source/upcoming_release_notes/302-repair_match_name_to_id.rst
@@ -1,0 +1,22 @@
+302 repair_match_name_to_id
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Issue 302: Add functionality to happi 'repair' that ensures that the name and id fields of a device are the same. 
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- laura-king

--- a/docs/source/upcoming_release_notes/302-repair_match_name_to_id.rst
+++ b/docs/source/upcoming_release_notes/302-repair_match_name_to_id.rst
@@ -11,7 +11,7 @@ Features
 
 Bugfixes
 --------
-- Issue 302: Add functionality to happi 'repair' that ensures that the name and id fields of a device are the same. 
+- Issue 302: Add functionality to happi 'repair' that ensures that the name and id fields of a device are the same.
 
 Maintenance
 -----------

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1149,7 +1149,7 @@ def repair(
         # check name and id parity
         if res['name'] != res_id:
             # set name to match id
-            setattr(res.item, 'name', res_id)
+            res.item.name = res_id
 
         # re-save after creating container
         try:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1153,15 +1153,20 @@ def repair(
         if fix_optional:
             req_info.extend(find_unfilled_optional_info(res))
 
-        res_name = res['_id']
+        res_id = res['_id']
 
         # fix each mandatory field
-        logger.info(f'repairing ({res_name})...')
+        logger.info(f'repairing ({res_id})...')
         for req_field in req_info:
             info = res.item._info_attrs[req_field]
             req_value = prompt_for_entry(info)
             info.enforce_value(req_value)
             setattr(res.item, req_field, req_value)
+
+        # check name and id parity
+        if res['name'] != res_id:
+            # set name to match id
+            setattr(res.item, 'name', res_id)
 
         # re-save after creating container
         try:

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -97,6 +97,23 @@ def test_cli_no_argument(runner: CliRunner):
     assert 'Commands:' in result.output
 
 
+def test_repair_name(runner: CliRunner, bad_happi_cfg: str):
+    search_string = '_id=tst_id'
+
+    # make sure the name and id are different
+    with search.make_context('search', [search_string], obj=bad_happi_cfg) as ctx:
+        res = search.invoke(ctx)
+    assert all([r['_id'] != r['name'] for r in res])
+
+    # run repair
+    runner.invoke(happi_cli, ['--path', bad_happi_cfg, 'repair', search_string])
+
+    # make sure the name and id are the same
+    with search.make_context('search', [search_string], obj=bad_happi_cfg) as ctx:
+        res = search.invoke(ctx)
+    assert all([r['_id'] == r['name'] for r in res])
+
+
 def test_search(client: happi.client.Client, happi_cfg: str):
     res = client.search_regex(beamline="TST")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When running happy repair, will check if name and id fields are matching. If not, will set the name field to the id field. 

Added comparison and attribute setting in repair function. Added click context-based unit test for setting name and id equivalence. 

Changed 'res_name' variable to 'res_id' to represent correct value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #302 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test using click contexts that call repair on the bad-happi-config.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
