### PR TITLE
BUG: remove extra pcdsutils import

### DIFF
--- a/docs/source/upcoming_release_notes/329-remove-extra-pcdsutils-import.rst
+++ b/docs/source/upcoming_release_notes/329-remove-extra-pcdsutils-import.rst
@@ -1,0 +1,22 @@
+329 remove-extra-pcdsutils-import
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Remove an extra pcdsutils import from test_cli.py that is not properly caught by error handling
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- laura-king

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -12,7 +12,6 @@ from unittest import mock
 
 import click
 import IPython
-import pcdsutils
 import pytest
 from click.testing import CliRunner
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Removed an extra pcdsutils import from test_cli.py that is outside of the try/except block with the other pcdsutils imports. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pytest will fail if pcdsutils is not installed in the environment. It appears to be imported in a later try/except block.

Pcdsutils also doesn't appear in any of the requirements files other than the workflows/standards.yml file. I haven't done anything about this, but felt that I should mention it. 

If we need another import within the try/except I'm happy to add it, or if I should add it in the requirements somewhere. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the pytest suite(after installing the up to date version of line-profiler(4.1.x) and pcdsutils) all tests pass 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Just this PR. 

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
