### PR TITLE
Remove temporary file in JSON backend store function

### DIFF
--- a/docs/source/upcoming_release_notes/304-remove_temporary_file.rst
+++ b/docs/source/upcoming_release_notes/304-remove_temporary_file.rst
@@ -1,4 +1,4 @@
-304 remove_temporar_file
+304 remove_temporary_file
 #################
 
 API Changes

--- a/docs/source/upcoming_release_notes/304-remove_temporary_file.rst
+++ b/docs/source/upcoming_release_notes/304-remove_temporary_file.rst
@@ -1,0 +1,23 @@
+304 remove_temporar_file
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adds error handling for the temporary file created when initializing a json backend object.
+- Changes format of temporary file name generation to contain only a unique hash.
+
+Contributors
+------------
+- laura-king

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -150,6 +150,7 @@ class JSONBackend(_Backend):
             # remove temporary file
             if os.path.exists(temp_path):
                 os.remove(temp_path)
+            raise
 
     def _temp_path(self) -> str:
         """

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -2,14 +2,12 @@
 Backend implemenation using the ``simplejson`` package.
 """
 import contextlib
-import getpass
 import logging
 import math
 import os
 import os.path
 import re
 import shutil
-import time
 import uuid
 from typing import Any, Callable, Optional, Union
 
@@ -151,7 +149,6 @@ class JSONBackend(_Backend):
             logger.debug('JSON db move failed: %s', ex, exc_info=ex)
             # remove temporary file
             if os.path.exists(temp_path):
-                print(f"we are removing {temp_path}")
                 os.remove(temp_path)
 
     def _temp_path(self) -> str:

--- a/happi/backends/json_db.py
+++ b/happi/backends/json_db.py
@@ -144,8 +144,6 @@ class JSONBackend(_Backend):
                 shutil.copymode(self.path, temp_path)
             shutil.move(temp_path, self.path)
         except BaseException as ex:
-
-            # log that the db move was not executed properly
             logger.debug('JSON db move failed: %s', ex, exc_info=ex)
             # remove temporary file
             if os.path.exists(temp_path):

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -202,6 +202,7 @@ def test_json_tempfile_uniqueness():
         tempfiles.append(jb._temp_path())
     assert len(set(tempfiles)) == len(tempfiles)
 
+
 def test_json_tempfile_remove(monkeypatch):
     # Set consistent temppath
     jb = JSONBackend("testing.json", initialize=False)
@@ -217,7 +218,7 @@ def test_json_tempfile_remove(monkeypatch):
 
     # Test, and ensure file is deleted appropriately
     jb.initialize()
-    assert os.path.exists(temp_path) == False
+    assert os.path.exists(temp_path) is False
 
 
 @requires_questionnaire

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -209,7 +209,7 @@ def test_json_tempfile_remove(monkeypatch):
     temp_path = jb._temp_path()
     jb._temp_path = lambda: temp_path
 
-    # Ensure file is created, then throw error
+    # Ensure file is created, then throw error through patching
     def shutil_move_patch(*args, **kwargs):
         assert os.path.isfile(os.path.join(os.getcwd(), temp_path))
         raise RuntimeError('Simulated testing error.')
@@ -217,7 +217,7 @@ def test_json_tempfile_remove(monkeypatch):
     monkeypatch.setattr('shutil.move', shutil_move_patch)
 
     # Test, and ensure file is deleted appropriately
-    with pytest.raises(BaseException):
+    with pytest.raises(RuntimeError):
         jb.initialize()
     assert os.path.exists(temp_path) is False
 

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -212,12 +212,13 @@ def test_json_tempfile_remove(monkeypatch):
     # Ensure file is created, then throw error
     def shutil_move_patch(*args, **kwargs):
         assert os.path.isfile(os.path.join(os.getcwd(), temp_path))
-        raise RuntimeError('Simulated error.')
+        raise RuntimeError('Simulated testing error.')
 
     monkeypatch.setattr('shutil.move', shutil_move_patch)
 
     # Test, and ensure file is deleted appropriately
-    jb.initialize()
+    with pytest.raises(BaseException):
+        jb.initialize()
     assert os.path.exists(temp_path) is False
 
 

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -202,6 +202,19 @@ def test_json_tempfile_uniqueness():
         tempfiles.append(jb._temp_path())
     assert len(set(tempfiles)) == len(tempfiles)
 
+def test_json_tempfile_remove(monkeypatch):
+    # Force the function to fail so there will be a temp file to remove
+    monkeypatch.setattr('shutil.move', no_op)
+    def no_op(*args, **kwargs):
+        raise Exception
+
+    # Ensure shutil.move raises an exception  
+    with pytest.raises(Exception):
+        jb = JSONBackend("testing.json", initialize=True)
+
+    # Ensure the temp file was removed correctly
+    assert os.path.exists(jb._temp_path) == False
+
 
 @requires_questionnaire
 def test_qs_find(mockqsbackend):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #304  

If an error causes the temporary file in the json backend to not get copied properly, it would previously remain in the directory. It has not been needed so it will now be removed if left behind. 

In addition, because this file is no longer needed, the datetime and username are no longer needed in the file name. It is now just the unique hash to prevent collisions. Imports previously used to add time and username are now removed from the file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively, and a new test in test-backends.py 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Issues #303, #304

Comments within function itself and test. 

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
