### PR TITLE
DOC: explain bson dependency to avoid confusion

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   run-constrained:
   - psdm_qs_cli >=0.3.1
   - pymongo >=4.0.2
+  # - bson  # bson is vendored by pymongo, and should not be installed separately
 
 test:
   commands:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,8 @@ ipython
 matplotlib >=3.2.0
 ophyd >=1.5.0
 pymongo
+# bson is vendored by pymongo, and should not be installed separately
+# bson
 pcdsutils
 pcdsdevices
 mongomock >=3.22.0

--- a/docs/source/upcoming_release_notes/333-doc_bson_not_req.rst
+++ b/docs/source/upcoming_release_notes/333-doc_bson_not_req.rst
@@ -1,0 +1,23 @@
+333 doc_bson_not_req
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Documents bson dependency.  Bson is vendored by pymongo, which instructs
+  users to not install bson from pypi (`pymongo readme <https://github.com/mongodb/mongo-python-driver/tree/master#installation>`)
+
+Contributors
+------------
+- tangkong

--- a/happi/backends/mongo_db.py
+++ b/happi/backends/mongo_db.py
@@ -5,12 +5,17 @@ import logging
 import re
 from typing import Any, Optional, Union
 
-import bson.regex
 from pymongo import MongoClient
 from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
 
 from ..errors import DatabaseError, DuplicateError, SearchError
 from .core import ItemMeta, ItemMetaGen, _Backend
+
+try:
+    import bson.regex
+except ImportError:
+    raise ImportError('Optional dependency mongodb not found; mongodb backend'
+                      'is not available.  (bson not found)')
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description
Documents `bson`'s presence in requirement files, and also adds a more descriptive ImportError in the one place we use it

## Motivation and Context
#325 

## How Has This Been Tested?
N/A, but CI should cover it

## Where Has This Been Documented?
this pr

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
