### PR TITLE
BLD: run_constrained not run-constrained

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
   - platformdirs
   - prettytable
   - simplejson
-  run-constrained:
+  run_constrained:
   - psdm_qs_cli >=0.3.1
   - pymongo >=4.0.2
   # - bson  # bson is vendored by pymongo, and should not be installed separately

--- a/docs/source/upcoming_release_notes/337-bld_run_constrained.rst
+++ b/docs/source/upcoming_release_notes/337-bld_run_constrained.rst
@@ -1,0 +1,22 @@
+337 bld_run_constrained
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Fix conda recipe to use "run_constrained" not "run-constrained"
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
change the header name in conda-recipe from `run-constrained` to `run_constrained`

## Motivation and Context
I was trying to fix conda feedstocks

## How Has This Been Tested?
ci?

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
