### PR TITLE
MNT: improve `happi audit` output

### DIFF
--- a/docs/source/upcoming_release_notes/339-mnt_audit_out.rst
+++ b/docs/source/upcoming_release_notes/339-mnt_audit_out.rst
@@ -1,0 +1,22 @@
+339 mnt_audit_out
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fixes audit output table skipping names
+
+Maintenance
+-----------
+- Adjusts audit output to work better for file redirects
+
+Contributors
+------------
+- tangkong

--- a/happi/audit.py
+++ b/happi/audit.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import io
+import sys
 from typing import Callable, Optional, TypedDict
 
 from jinja2 import DebugUndefined, Environment, meta
@@ -265,7 +266,7 @@ def audit(
 
     try:
         for i, res in enumerate(results):
-            if verbose:
+            if verbose and sys.__stdout__.isatty():
                 print(f"checking device #: {i}", end="\r")
 
             # Capture stdout, stderr for this audit

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1093,7 +1093,8 @@ def audit(
             term_width = os.get_terminal_size()[0]
             pt._max_width = {'error': max(60, term_width - 40)}
         except OSError:
-            # non-interactive mode (piping results). No max width
+            # non-interactive mode (piping results). default max width
+            pt._max_width = {'error': 100}
             pass
 
         if len(pt.rows) > 0:

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1082,10 +1082,12 @@ def audit(
                                              test_results['msg']):
             if not success:
                 if name != last_name:
+                    if last_name != '':  # initial condition
+                        pt.add_row(['', '', ''], divider=True)
                     pt.add_row([name, check, msg])
                 else:
                     pt.add_row(['', check, msg])
-            last_name = name
+                last_name = name
 
         try:
             term_width = os.get_terminal_size()[0]


### PR DESCRIPTION
## Description
- gives non-interactive audit tables a max width
- fixes bad logic in table construction

## Motivation and Context
I want audits to be more useful
closes #338 

## How Has This Been Tested?
interactively

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
