### PR TITLE
MNT: make happi repair not save items that have no changed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,20 @@ specified by the container.
 
    dev.save()
 ```
+
+#### Command Line Interface
+
+You can also view and manipulate device databases using the happi cli:
+
+```
+happi [OPTIONS] COMMAND [ARGS]...
+```
+
+You can try out happi commands on a simple test database as follows _(this assumes you are running from the happi project root dir)_:
+
+```
+happi --path examples/example.cfg COMMAND [ARGS]
+```
+
+The simple test database is located at `happi/examples/db.json`, which is specified in `example./cfg`.
+Please refer to the documentation for a list of possible commands and their arguments.

--- a/docs/source/upcoming_release_notes/324-repair_no_changes.rst
+++ b/docs/source/upcoming_release_notes/324-repair_no_changes.rst
@@ -1,0 +1,23 @@
+324 repair_no_changes
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Make running happi repair only saves an item if it actually got changed during the repair process
+- Add example .cfg and some more instructions on using happi cli
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/324-repair_no_changes.rst
+++ b/docs/source/upcoming_release_notes/324-repair_no_changes.rst
@@ -20,4 +20,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- nstelter-slac

--- a/examples/example.cfg
+++ b/examples/example.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+path = db.json

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -1122,6 +1122,8 @@ def repair(
     Repair the database.
 
     Repairs all entries matching SEARCH_CRITERIA, repairs entire database otherwise.
+
+    Entries that don't get any fields changed will not get saved (i.e. their last-edit times will not change).
     """
     logger.debug('starting repair block')
 

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -123,6 +123,21 @@ def test_repair_name(runner: CliRunner, bad_happi_cfg: str):
     assert all([r['_id'] == r['name'] for r in res])
 
 
+def test_repair_no_save_if_no_changes(runner: CliRunner, happi_cfg: str):
+    # some arbitrary entry
+    search_string = '_id=tst_base_pim'
+
+    # run repair, which should find it doesn't neeod to repair the name and so doesn't need to save
+    runner.invoke(happi_cli, ['--path', happi_cfg, 'repair', search_string])
+
+    with search.make_context('search', [search_string], obj=happi_cfg) as ctx:
+        res = search.invoke(ctx)
+    last_edit_time = res[0]['last_edit']
+    # lets assume the starting values in happi_cfg stay the same,
+    # since other tests in this file also rely on it too.
+    assert last_edit_time == 'Thu Apr 12 14:40:08 2018'
+
+
 def test_search(client: happi.client.Client, happi_cfg: str):
     res = client.search_regex(beamline="TST")
 

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -125,15 +125,20 @@ def test_repair_no_save_if_no_changes(runner: CliRunner, happi_cfg: str):
     # some arbitrary entry
     search_string = '_id=tst_base_pim'
 
-    # run repair, which should find it doesn't neeod to repair the name and so doesn't need to save
+    # get last edit time of item, so can make sure it isn't changed by repair
+    with search.make_context('search', [search_string], obj=happi_cfg) as ctx:
+        res = search.invoke(ctx)
+    pre_repair_edit_time = res[0]['last_edit']
+
+    # run repair, which should find it doesn't need to repair the item's name and so doesn't need to save
     runner.invoke(happi_cli, ['--path', happi_cfg, 'repair', search_string])
 
     with search.make_context('search', [search_string], obj=happi_cfg) as ctx:
         res = search.invoke(ctx)
-    last_edit_time = res[0]['last_edit']
-    # lets assume the starting values in happi_cfg stay the same,
-    # since other tests in this file also rely on it too.
-    assert last_edit_time == 'Thu Apr 12 14:40:08 2018'
+    after_repair_edit_time = res[0]['last_edit']
+
+    # should not have saved, so edit time should be unchanged
+    assert after_repair_edit_time == pre_repair_edit_time
 
 
 def test_search(client: happi.client.Client, happi_cfg: str):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Make it so running `happi repair` only saves an item if it had a field actually changed during the repair process. This stops the last_edit times from being updated on unchanged items.

Also, it wasn't immediately clear to me how to use the cli along with the example db.json (so I could try commands on a small example db). So added an example cfg and some instructions to the README to make this easy.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
closes #324 

## How Has This Been Tested?
Manually tested and verified, and test case added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
In function's doc string and comments.
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
