### PR TITLE
TST: Properly test with pymongo, adjust profiler usage for py3.12

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -47,6 +47,7 @@ test:
   - mongomock
   - pcdsutils
   - pcdsdevices
+  - pymongo
 
 about:
   dev_url: https://github.com/pcdshub/happi/

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
   - pytest
   - ipython
   - line_profiler
+  - mongomock
   - pcdsutils
   - pcdsdevices
 

--- a/happi/tests/test_backends.py
+++ b/happi/tests/test_backends.py
@@ -268,6 +268,7 @@ def test_beckoff_axis_device_class(mockqsbackend):
     assert sam_x.__class__.__name__ == 'IMS'
 
 
+@requires_mongo
 def test_multi_backend(mockmulti, item_info, valve_info):
     mm = mockmulti
     assert len(mm.all_items) == 3

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -1,10 +1,8 @@
 # test_cli.py
 
-import cProfile
 import functools
 import itertools
 import logging
-import pstats
 import re
 from collections.abc import Iterable
 from typing import Any
@@ -829,14 +827,11 @@ def test_profile_cli(runner: CliRunner, happi_cfg: str, args: tuple[str]):
         print("Resetting the line profiler...")
         pcdsutils.profile.reset_profiler()
 
-    with cProfile.Profile() as pr:
-        result = runner.invoke(
-            happi_cli,
-            ['--path', happi_cfg, 'profile'] + list(args),
-        )
+    result = runner.invoke(
+        happi_cli,
+        ['--path', happi_cfg, 'profile'] + list(args),
+    )
 
-    st = pstats.Stats(pr).strip_dirs().sort_stats("tottime")
-    st.print_stats(20)
     assert_in_expected(
         result,
         'Profile completed successfully'


### PR DESCRIPTION
## Description
- Properly mark `test_multi_backend` as needing pymongo.  (its fixtures had this decorator already, but the test still tried to run 🤷 )

## Motivation and Context
Seen in #343 and others

## How Has This Been Tested?
CI

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
