### PR TITLE
FIX: make tst_pim_2 loadable, types.SimpleNamespace does not take positional args

### DIFF
--- a/docs/source/upcoming_release_notes/349-bug_args_simplenamespace.rst
+++ b/docs/source/upcoming_release_notes/349-bug_args_simplenamespace.rst
@@ -1,0 +1,22 @@
+349 bug_args_simplenamespace
+############################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fixes issue in test suite, making tst_base_pim2 a loadable SimpleNamespacce
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -429,9 +429,6 @@ def db(tmp_path):
     "tst_base_pim2": {
         "_id": "tst_base_pim2",
         "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
         "beamline": "TST",
         "creation": "Wed Jan 30 09:46:00 2019",
         "device_class": "types.SimpleNamespace",

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -269,9 +269,7 @@ def test_search_json(runner: CliRunner, happi_cfg: str):
   {
     "name": "tst_base_pim2",
     "device_class": "types.SimpleNamespace",
-    "args": [
-      "{{prefix}}"
-    ],
+    "args": [],
     "kwargs": {
       "name": "{{name}}"
     },


### PR DESCRIPTION
## Description
In conftest.py, we defined a mock database with some SimpleNamespace devices.  

## Motivation and Context
Jane ran into this, uncovering a poorly written test (very likely my fault)

Many of the tests in happi are also quite brittle.  I'd love to blame someone else for this but I did go through rewriting tests for click and did not fix this problem.

## How Has This Been Tested?
pytest

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
