### PR TITLE
BLD: Try swapping to line_profiler, seems the same as line-profiler

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,4 +11,4 @@ pcdsdevices
 mongomock >=3.22.0
 # Removed temporarily, pip installations fail lacking gssapi libs
 # psdm_qs_cli
-line-profiler
+line_profiler

--- a/docs/source/upcoming_release_notes/352-bld_pip_profiler.rst
+++ b/docs/source/upcoming_release_notes/352-bld_pip_profiler.rst
@@ -1,0 +1,22 @@
+352 bld_pip_profiler
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Use `line_profiler` in pip dev_requirements instead of `line-profiler` to avoid confusion
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
* replaces `line-profiler` with `line_profiler` in `dev-requirements.txt` 

## Motivation and Context
In a very roundabout way trying to get prepped for py3.12.

These two packages seem to be identical on pypi, and typhos already lists the underscore version as a dev-requirement.

the underscore version is available on conda-forge, and prevents confusion/mismatch with our build scripts

## How Has This Been Tested?
CI runs 🤷 Package builds 🤷 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
