### PR TITLE
BLD: split ui dependencies into subpackage

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,9 +4,6 @@ pytest-qt
 ipython
 matplotlib >=3.2.0
 ophyd >=1.5.0
-pymongo
-# bson is vendored by pymongo, and should not be installed separately
-# bson
 pcdsutils
 pcdsdevices
 mongomock >=3.22.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-cov
+pytest-qt
 ipython
 matplotlib >=3.2.0
 ophyd >=1.5.0

--- a/docs/source/upcoming_release_notes/353-bld_subpackage.rst
+++ b/docs/source/upcoming_release_notes/353-bld_subpackage.rst
@@ -1,0 +1,24 @@
+353 bld_subpackage
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Splits happi pip package into subpackages (`gui`, `mongo`) for more precise dependency specification.
+  The default dependency set has can be installed via `pip install happi[all]`, and includes
+  the `gui` and `mongo` optional dependencies.
+
+Contributors
+------------
+- tangkong

--- a/gui-requirements.txt
+++ b/gui-requirements.txt
@@ -1,0 +1,2 @@
+PyQt5
+qtpy

--- a/happi/tests/test_qt.py
+++ b/happi/tests/test_qt.py
@@ -1,12 +1,16 @@
 import pytest
-from pytestqt.qtbot import QtBot
 
 from happi.client import Client
 
 try:
+    from pytestqt.qtbot import QtBot
+
     from happi.qt.widgets import HappiItemMetadataView, HappiSearchWidget
     qt_missing = False
 except ImportError:
+    class QtBot:
+        pass
+
     HappiSearchWidget = None
     HappiItemMetadataView = None
     qt_missing = True

--- a/happi/tests/test_qt.py
+++ b/happi/tests/test_qt.py
@@ -1,0 +1,24 @@
+import pytest
+from pytestqt.qtbot import QtBot
+
+from happi.client import Client
+
+try:
+    from happi.qt.widgets import HappiItemMetadataView, HappiSearchWidget
+    qt_missing = False
+except ImportError:
+    HappiSearchWidget = None
+    HappiItemMetadataView = None
+    qt_missing = True
+
+
+@pytest.mark.skipif(qt_missing, reason="qt packages not installed")
+def test_search_widget(qtbot: QtBot, mockjsonclient: Client):
+    search_widget = HappiSearchWidget(client=mockjsonclient)
+    qtbot.addWidget(search_widget)
+
+
+@pytest.mark.skipif(qt_missing, reason="qt packages not installed")
+def test_item_view(qtbot: QtBot, mockjsonclient: Client):
+    search_widget = HappiItemMetadataView(client=mockjsonclient)
+    qtbot.addWidget(search_widget)

--- a/mongo-requirements.txt
+++ b/mongo-requirements.txt
@@ -1,0 +1,3 @@
+# bson is vendored by pymongo and should not be directly installed
+# bson
+pymongo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,17 @@ file = [ "requirements.txt",]
 [tool.setuptools.dynamic.optional-dependencies.gui]
 file = "gui-requirements.txt"
 
+[tool.setuptools.dynamic.optional-dependencies.mongo]
+file = "mongo-requirements.txt"
+
 [tool.setuptools.dynamic.optional-dependencies.test]
-file = ["dev-requirements.txt", "gui-requirements.txt"]
+file = ["dev-requirements.txt", "gui-requirements.txt", "mongo-requirements.txt"]
 
 [tool.setuptools.dynamic.optional-dependencies.doc]
 file = "docs-requirements.txt"
+
+[tool.setuptools.dynamic.optional-dependencies.all]
+file = ["gui-requirements.txt", "mongo-requirements.txt"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,11 @@ content-type = "text/markdown"
 [tool.setuptools.dynamic.dependencies]
 file = [ "requirements.txt",]
 
+[tool.setuptools.dynamic.optional-dependencies.gui]
+file = "gui-requirements.txt"
+
 [tool.setuptools.dynamic.optional-dependencies.test]
-file = "dev-requirements.txt"
+file = ["dev-requirements.txt", "gui-requirements.txt"]
 
 [tool.setuptools.dynamic.optional-dependencies.doc]
 file = "docs-requirements.txt"


### PR DESCRIPTION
## Description
Splits happi gui dependencies into subpackages (pip) or separate outputs (conda)

## Motivation and Context
closes #347 
closes #340 

## How Has This Been Tested?
Added some ui tests, but mostly relying on CI here to assess failure

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
