### PR TITLE
First pass at allowing for cached devices to be used as args to enabl…

### DIFF
--- a/examples/load_ophyd_async_devices.py
+++ b/examples/load_ophyd_async_devices.py
@@ -1,0 +1,38 @@
+from bluesky.run_engine import RunEngine
+import happi
+import happi.loader
+from IPython import get_ipython
+from types import SimpleNamespace
+from bluesky.plans import count, scan
+from ophyd_async.plan_stubs import ensure_connected
+
+ip = get_ipython()
+
+client = happi.Client(path="ophyd_async_db.json")
+
+from ophyd_async.core import init_devices
+
+print("Initializing bluesky RunEngine...")
+RE = RunEngine({})
+
+init_ns = SimpleNamespace()
+
+print("Instantiating all helper objects...")
+happi.loader.load_devices(
+    *[result.item for result in client.search(type="HappiItem")],
+    pprint=True,
+    include_load_time=True,
+    namespace=init_ns,
+)
+
+print("Initializing Ophyd Async devices...")
+happi.loader.load_devices(
+    *[result.item for result in client.search(type="OphydAsyncItem")],
+    pprint=True,
+    include_load_time=True,
+    post_load=lambda device: RE(ensure_connected(device)),
+    namespace=init_ns,
+)
+
+ip.user_ns.update(vars(init_ns))
+print("Done.")

--- a/examples/ophyd_async_db.json
+++ b/examples/ophyd_async_db.json
@@ -1,0 +1,85 @@
+{
+    "uuid_filename_provider": {
+        "_id": "uuid_fp",
+        "active": true,
+        "args": [
+        ],
+        "creation": "Tue Feb 11 12:48:00 2025",
+        "device_class": "ophyd_async.core.UUIDFilenameProvider",
+        "documentation": null,
+        "kwargs": {
+        },
+        "last_edit": "Tue Feb 11 12:48:00 2025",
+        "name": "uuid_fp",
+        "type": "HappiItem"
+    },
+    "ymd_path_provider": {
+        "_id": "ymd_pp",
+        "active": true,
+        "args": [
+            "{{uuid_fp}}",
+            "/tmp"
+        ],
+        "creation": "Tue Feb 11 12:48:00 2025",
+        "device_class": "ophyd_async.core.YMDPathProvider",
+        "documentation": null,
+        "kwargs": {
+            "create_dir_depth": -4
+        },
+        "last_edit": "Tue Feb 11 12:48:00 2025",
+        "name": "ymd_pp",
+        "type": "HappiItem"
+    },
+    "manta_cam1": {
+        "_id": "manta_cam1",
+        "active": true,
+        "args": [
+            "{{prefix}}",
+            "{{ymd_pp}}"
+        ],
+        "creation": "Tue Feb 11 12:48:00 2025",
+        "device_class": "ophyd_async.epics.advimba.VimbaDetector",
+        "documentation": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 11 12:48:00 2025",
+        "name": "manta_cam1",
+        "prefix": "XF:31ID1-ES{GigE-Cam:1}",
+        "type": "OphydAsyncItem"
+    },
+    "ophyd_async_sim_motor_1": {
+        "_id": "ophyd_async_sim_motor_1",
+        "active": true,
+        "args": [
+
+        ],
+        "creation": "Tue Feb 11 12:48:00 2025",
+        "device_class": "ophyd_async.sim.SimMotor",
+        "documentation": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 11 12:48:00 2025",
+        "name": "ophyd_async_sim_motor_1",
+        "prefix": "ASYNC-MTR:SIM1:",
+        "type": "OphydAsyncItem"
+    },
+    "ophyd_async_sim_motor_2": {
+        "_id": "ophyd_async_sim_motor_2",
+        "active": true,
+        "args": [
+
+        ],
+        "creation": "Tue Feb 11 12:48:00 2025",
+        "device_class": "ophyd_async.sim.SimMotor",
+        "documentation": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 11 12:48:00 2025",
+        "name": "ophyd_async_sim_motor_2",
+        "prefix": "ASYNC-MTR:SIM2:",
+        "type": "OphydAsyncItem"
+    }
+}

--- a/happi/__init__.py
+++ b/happi/__init__.py
@@ -5,11 +5,12 @@ __all__ = [
     "EntryInfo",
     "HappiItem",
     "OphydItem",
+    "OphydAsyncItem",
     "SearchResult",
     "cache",
     "from_container",
     "load_devices",
 ]
 from .client import Client, SearchResult
-from .item import EntryInfo, HappiItem, OphydItem
+from .item import EntryInfo, HappiItem, OphydItem, OphydAsyncItem
 from .loader import cache, from_container, load_devices

--- a/happi/containers.py
+++ b/happi/containers.py
@@ -5,14 +5,14 @@ from typing import ClassVar, Optional
 
 import entrypoints
 
-from .item import HappiItem, OphydItem
+from .item import HappiItem, OphydItem, OphydAsyncItem
 
 logger = logging.getLogger(__name__)
 
 HAPPI_ENTRY_POINT_KEY = "happi.containers"
 
 
-DEFAULT_REGISTRY = {"OphydItem": OphydItem, "HappiItem": HappiItem}
+DEFAULT_REGISTRY = {"OphydItem": OphydItem, "OphydAsyncItem": OphydAsyncItem, "HappiItem": HappiItem}
 
 
 class HappiRegistry:

--- a/happi/item.py
+++ b/happi/item.py
@@ -416,8 +416,11 @@ class HappiItem(_HappiItemBase, collections.abc.Mapping):
 class OphydItem(HappiItem):
     prefix = EntryInfo("A base PV for all related records",
                        optional=False, enforce=str)
-
     args = copy.copy(HappiItem.args)
     args.default = ['{{prefix}}']
     kwargs = copy.copy(HappiItem.kwargs)
     kwargs.default = {'name': '{{name}}'}
+
+
+class OphydAsyncItem(OphydItem):
+    ...

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -48,19 +48,32 @@ def fill_template(
         string-rendered template if ``enforce_type`` is False, or if happi is
         unable to cast the rendered value to the given type.
     """
+
     # Create a template and render our happi information inside it
     env = Environment().from_string(template)
     filled = env.render(**item.post())
     # Find which variable we used in the template, get the type and convert our
     # rendered template to agree with this
     info = meta.find_undeclared_variables(env.environment.parse(template))
-    if len(info) != 1 or not enforce_type:
-        # Enforcing types only works with 1 attribute name in the template
+
+    # If we have 0 or more than 1 variables in template, cannot enforce type
+    # or replace with cached item
+    if len(info) != 1:
+        return filled
+
+    # Get the name of the single attribute in the template
+    attr_name = info.pop()
+
+    # If the templated variable is in the cache, use it directly.
+    if attr_name in cache:
+        return cache[attr_name]
+
+    # If we are not enforcing types we can just return the rendered template
+    elif not enforce_type:
         return filled
 
     # Get the original attribute back from the item. If this does not exist
     # there is a possibility it is a piece of metadata e.t.c
-    attr_name = info.pop()
     try:
         typed_attr = getattr(item, attr_name)
     except AttributeError:


### PR DESCRIPTION
…e ophyd-async support

<!--- Provide a general summary of your changes in the Title above -->
## Description
* Adds `OphydAsyncItem` class that allows for filtering for ophyd-async devices only since they require an additional step to establish a connection to the control system.
* Adds the ability to use cached devices as arguments and kwargs, which allows for instantiating some of the more complex ophyd async devices.
* Adds example database that instantiates an ophyd async detector + required provider objects.
* Adds minimal example script to outline how ophyd async devices can be loaded.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Allows for seamless utilization of happi w/ ophyd-async devices.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TODO: Unit tests, ensure existing test suite passes. Marking as draft for review & until I have a chance to complete these.

I did test with a real camera:

```
(venv) [jwlodek@xf31id1-ioc1 examples]$ ipython
Python 3.12.8 (main, Dec  9 2024, 15:25:01) [GCC 8.5.0 20210514 (Red Hat 8.5.0-22)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.32.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: %run load_ophyd_async_devices.py
Initializing bluesky RunEngine...
Instantiating all helper objects...
Loading uuid_fp [ophyd_async.core.UUIDFilenameProvider] ... SUCCESS!
Loading ymd_pp [ophyd_async.core.YMDPathProvider] ... SUCCESS!
Initializing Ophyd Async devices...
Loading manta_cam1 [ophyd_async.epics.advimba.VimbaDetector] ... SUCCESS!
Loading ophyd_async_sim_motor_1 [ophyd_async.sim.SimMotor] ... SUCCESS!
Loading ophyd_async_sim_motor_2 [ophyd_async.sim.SimMotor] ... SUCCESS!
Done.

In [2]: RE(count([manta_cam1], num=5))
Out[2]: ('1f910933-9d0e-4962-96c9-7f6474b834be',)

In [3]: !ls /tmp/manta_cam1/2025/02/12/
6f6db019-7869-43bb-a1fe-4ec4dae9e42c.h5  ad9f9d4b-a8fc-42e6-96aa-f7c7a0523b7b.h5

In [4]: !h5dump /tmp/manta_cam1/2025/02/12/ad9f9d4b-a8fc-42e6-96aa-f7c7a0523b7b.h5
HDF5 "/tmp/manta_cam1/2025/02/12/ad9f9d4b-a8fc-42e6-96aa-f7c7a0523b7b.h5" {
GROUP "/" {
   GROUP "entry" {
      ATTRIBUTE "NX_class" {
         DATATYPE  H5T_STRING {
            STRSIZE 8;
            STRPAD H5T_STR_NULLTERM;
            CSET H5T_CSET_ASCII;
            CTYPE H5T_C_S1;
         }
         DATASPACE  SCALAR
         DATA {
         (0): "NXentry"
         }
      }
      GROUP "data" {
         ATTRIBUTE "NX_class" {
            DATATYPE  H5T_STRING {
               STRSIZE 7;
               STRPAD H5T_STR_NULLTERM;
               CSET H5T_CSET_ASCII;
               CTYPE H5T_C_S1;
            }
            DATASPACE  SCALAR
            DATA {
            (0): "NXdata"
            }
         }
         DATASET "data" {
            DATATYPE  H5T_STD_U8LE
            DATASPACE  SIMPLE { ( 5, 544, 728 ) / ( H5S_UNLIMITED, 544, 728 ) }
...
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
TODO

<!--
## Screenshots (if appropriate):
-->
![image](https://github.com/user-attachments/assets/17c5dcf8-d134-4d8e-a7ee-cbcd26dadb7e)


## Pre-merge checklist
- [X] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
