### PR TITLE
MNT: make happi.cli.search_parser always return a list

### DIFF
--- a/docs/source/upcoming_release_notes/357-mnt_cli_annotations.rst
+++ b/docs/source/upcoming_release_notes/357-mnt_cli_annotations.rst
@@ -1,0 +1,23 @@
+357 mnt_cli_annotations
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Fixes a variety of typing mistakes
+- Fixes `happi transfer` to use the public `happi.containers.registry` API rather than internals
+
+Contributors
+------------
+- tangkong

--- a/happi/audit.py
+++ b/happi/audit.py
@@ -11,7 +11,7 @@ import contextlib
 import inspect
 import io
 import sys
-from typing import Callable, Optional, TypedDict
+from typing import Callable, List, Optional, TypedDict
 
 from jinja2 import DebugUndefined, Environment, meta
 
@@ -321,6 +321,11 @@ def audit(
     return audit_results
 
 
-checks = [check_instantiation, check_extra_info, check_name_match_id,
-          check_wait_connection, check_args_kwargs_match,
-          check_unfilled_mandatory_info]
+checks: List[Check] = [
+    check_instantiation,
+    check_extra_info,
+    check_name_match_id,
+    check_wait_connection,
+    check_args_kwargs_match,
+    check_unfilled_mandatory_info,
+]

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -156,6 +156,11 @@ def search_parser(
         regex matching.
     search_criteria : list of str
         The user's search selection from the command line.
+
+    Raises
+    ------
+    click.ClickException
+        Thrown if search criteria are invalid.
     """
     # Get search criteria into dictionary for use by client
     client_args = {}
@@ -232,7 +237,7 @@ def search_parser(
         final_results = range_list
     elif range_list and regex_list:
         # find the intersection between regex_list and range_list
-        final_results = set(range_list) & set(regex_list)
+        final_results = list(set(range_list) & set(regex_list))
     else:
         logger.debug('No regex or range items found')
 
@@ -1145,7 +1150,8 @@ def repair(
 
     Repairs all entries matching SEARCH_CRITERIA, repairs entire database otherwise.
 
-    Entries that don't get any fields changed will not get saved (i.e. their last-edit times will not change).
+    Entries that don't get any fields changed will not get saved
+    (i.e. their last-edit times will not change).
     """
     logger.debug('starting repair block')
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -164,7 +164,7 @@ def search_parser(
     """
     # Get search criteria into dictionary for use by client
     client_args: Dict[str, Any] = {}
-    range_list = []
+    range_set = set()
     regex_list = []
     range_found = False
 
@@ -193,12 +193,12 @@ def search_parser(
                 if not range_found:
                     # if first range, just replace
                     range_found = True
-                    range_list = new_range_list
+                    range_set = set(new_range_list)
                 else:
                     # subsequent ranges, only take intersection
-                    range_list = list(set(new_range_list) & set(range_list))
+                    range_set = set(new_range_list) & set(range_set)
 
-                if not range_list:
+                if not range_set:
                     # we have searched via a range query.  At this point
                     # no matches, or intesection is empty. abort early
                     logger.error("No items found")
@@ -229,15 +229,15 @@ def search_parser(
 
     # Gather final results
     final_results = []
-    if regex_list and not range_list:
+    if regex_list and not range_set:
         # only matched with one search_regex()
         final_results = regex_list
-    elif range_list and not regex_list:
+    elif range_set and not regex_list:
         # only matched with search_range()
-        final_results = range_list
-    elif range_list and regex_list:
+        final_results = list(range_set)
+    elif range_set and regex_list:
         # find the intersection between regex_list and range_list
-        final_results = list(set(range_list) & set(regex_list))
+        final_results = list(range_set & set(regex_list))
     else:
         logger.debug('No regex or range items found')
 


### PR DESCRIPTION
## Description
- Makes the return type for `happi.cli.search_parser` always a list.  Previously this could sometimes return a `Set`
- Runs through a variety of type hinting problems revealed by mypy
- Fixes a straggling reference to `happi.containers.registry._registry`, uses the public API instead (`happi.containers.registry[]`)
- Makes a set -> list conversion in `happi.cli.load` more concise

## Motivation and Context
Closes #354 

I ran `mypy` along the way and ended up doing a bunch of other random things.  Including
- Not overwriting variables when changing types

## How Has This Been Tested?
Makes sure the test still ran, plus some interactive testing

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
