### PR TITLE
TST: update test_cli_no_argument, updated click returns non-zero when no args passed

### DIFF
--- a/docs/source/upcoming_release_notes/360-tst_no_arg.rst
+++ b/docs/source/upcoming_release_notes/360-tst_no_arg.rst
@@ -1,0 +1,22 @@
+360 tst_no_arg
+##############
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Update test suite to handle no-arg case in cli for click>=8.2.0
+
+Contributors
+------------
+- tangkong

--- a/happi/tests/test_cli.py
+++ b/happi/tests/test_cli.py
@@ -98,8 +98,9 @@ def assert_in_expected(
 
 def test_cli_no_argument(runner: CliRunner):
     result = runner.invoke(happi_cli)
-    assert result.exit_code == 0
-    assert result.exception is None
+    # click >= 8.2.0 returns 2, not 0.
+    # Non-0 with no args the case in other cli's (git), even if help text is shown
+    # to support older versions of click we'll just skip the exit code check
     assert 'Usage:' in result.output
     assert 'Options:' in result.output
     assert 'Commands:' in result.output


### PR DESCRIPTION
## Description
Update test suite to handle new and old version of click.
Don't check exit code for cli when no arguments are passed

## Motivation and Context
Apparently click < 8.2.0 returned 0 when no args were passed to the cli program.  This was changed to 2 in 8.2.0 to match other cli programs

## How Has This Been Tested?
Interactively, and in CI

## Where Has This Been Documented?
This PR
https://github.com/pallets/click/releases/tag/8.2.0

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
