### PR TITLE
BUG/MNT: return InvalidResult if container is malformed

### DIFF
--- a/happi/audit.py
+++ b/happi/audit.py
@@ -15,6 +15,8 @@ from typing import Callable, List, Optional, TypedDict
 
 from jinja2 import DebugUndefined, Environment, meta
 
+from happi.client import InvalidResult
+
 from . import SearchResult
 
 CLIENT_KEYS = ['_id', 'type', 'creation', 'last_edit']
@@ -269,6 +271,9 @@ def audit(
             if verbose and sys.__stdout__.isatty():
                 print(f"checking device #: {i}", end="\r")
 
+            if isinstance(res, InvalidResult):
+                continue
+
             # Capture stdout, stderr for this audit
             with maybe_redirect():
                 for check_fn in check_list:
@@ -304,7 +309,8 @@ def audit(
         "failed_names": sorted(unique_fails),
         "items": {
             name: {"failed_check": [], "audit_errors": []}
-            for name in [res.item.name for res in results]
+            for name in [res.item.name for res in results
+                         if isinstance(res, SearchResult)]
         },
     }
     item_info = audit_results["items"]

--- a/happi/backends/mongo_db.py
+++ b/happi/backends/mongo_db.py
@@ -145,7 +145,7 @@ class MongoBackend(_Backend):
         match.update(**to_match)
         yield from self._collection.find(match)
 
-    def get_by_id(self, _id: str) -> ItemMeta:
+    def get_by_id(self, _id: str) -> Optional[ItemMeta]:
         """
         Get an item by ID if it exists, or return None.
 

--- a/happi/client.py
+++ b/happi/client.py
@@ -10,6 +10,7 @@ import re
 import sys
 import time as ttime
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any, Optional, Union
 
 import platformdirs
@@ -68,7 +69,6 @@ class SearchResult(collections.abc.Mapping):
         return self._item
 
     def get(self, attach_md=True, use_cache=True, threaded=False):
-        '''(get) ''' + from_container.__doc__
         if self._instantiated is None:
             self._instantiated = from_container(
                 self.item, attach_md=attach_md, use_cache=use_cache,
@@ -810,7 +810,7 @@ class Client(collections.abc.Mapping):
         return _id
 
     @classmethod
-    def from_config(cls, cfg=None):
+    def from_config(cls, cfg: Optional[Union[str, os.PathLike]] = None):
         """
         Create a client from a configuration file specification.
 
@@ -836,6 +836,10 @@ class Client(collections.abc.Mapping):
         if not cfg:
             cfg = cls.find_config()
 
+        if cfg is None:
+            raise RuntimeError("No config found or provided")
+
+        cfg = Path(cfg)
         if not os.path.exists(cfg):
             raise RuntimeError(f'happi configuration file not found: {cfg!r}')
 
@@ -872,8 +876,8 @@ class Client(collections.abc.Mapping):
     @staticmethod
     def _get_backend_from_config(
         cfg_section: configparser.SectionProxy,
-        cfg: str
-    ) -> _Backend:
+        cfg: Union[str, os.PathLike]
+    ) -> Optional[_Backend]:
         # If a backend is specified use it, otherwise default
         if 'backend' in cfg_section:
             db_str = cfg_section.pop('backend')

--- a/happi/client.py
+++ b/happi/client.py
@@ -10,7 +10,7 @@ import re
 import sys
 import time as ttime
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import platformdirs
 
@@ -100,6 +100,34 @@ class SearchResult(collections.abc.Mapping):
 
     def __hash__(self) -> int:
         return hash((self.client.backend, self['_id']))
+
+
+class InvalidResult(collections.abc.Mapping):
+    """
+    A result from Client.search that could not be resolved to a valid HappiItem.
+    """
+
+    def __init__(self, doc: dict[str, Any], exc: Exception):
+        self.metadata = doc
+        self.exception = exc
+
+    def __getitem__(self, item):
+        return self.metadata[item]
+
+    def __iter__(self):
+        yield from self.metadata
+
+    def __len__(self):
+        return len(self.metadata)
+
+    def __repr__(self):
+        return (
+            f'{self.__class__.__name__}(metadata={self.metadata}, '
+            f'exception={type(self.exception)})'
+        )
+
+
+GenericResult = Union[SearchResult, InvalidResult]
 
 
 class Client(collections.abc.Mapping):
@@ -484,14 +512,21 @@ class Client(collections.abc.Mapping):
     @property
     def all_items(self):
         """A list of all contained items."""
-        return [res.item for res in self.search()]
+        return [res.item for res in self.search()
+                if isinstance(res, SearchResult)]
 
     def __getitem__(self, key):
         """Get an item ID."""
+        item_doc = self.backend.get_by_id(key)
+
+        if item_doc is None:
+            raise KeyError(key)
+
         try:
-            item = self._get_item_from_document(self.backend.get_by_id(key))
+            item = self._get_item_from_document(item_doc)
         except Exception as ex:
-            raise KeyError(key) from ex
+            # create an InvalidResult, but don't raise
+            return InvalidResult(item_doc, exc=ex)
 
         return SearchResult(client=self, item=item)
 
@@ -509,7 +544,7 @@ class Client(collections.abc.Mapping):
 
     def _get_search_results(
         self, docs: Sequence[dict[str, Any]], *, wrap_cls: Optional[type] = None
-    ) -> list[SearchResult]:
+    ) -> list[GenericResult]:
         """
         Return search results to the user, optionally wrapping with a class.
         """
@@ -530,11 +565,13 @@ class Client(collections.abc.Mapping):
                     "Entry for %s is malformed (%s). Skipping.",
                     doc["name"], exc
                 )
+                results.append(InvalidResult(doc, exc))
+
         return results
 
     def search_range(
         self, key: str, start: float, end: Optional[float] = None, **kwargs
-    ) -> list[SearchResult]:
+    ) -> list[GenericResult]:
         """
         Search the database for an item or items using a numerical range.
 
@@ -568,7 +605,7 @@ class Client(collections.abc.Mapping):
                                         to_match=kwargs)
         return self._get_search_results(items)
 
-    def search(self, **kwargs):
+    def search(self, **kwargs) -> list[GenericResult]:
         """
         Search the database for item(s).
 
@@ -597,7 +634,7 @@ class Client(collections.abc.Mapping):
 
     def search_regex(
         self, flags=re.IGNORECASE, **kwargs
-    ) -> list[SearchResult]:
+    ) -> list[GenericResult]:
         """
         Search the database for items(s).
 
@@ -613,7 +650,7 @@ class Client(collections.abc.Mapping):
 
         Returns
         -------
-        list of SearchResult
+        list of GenericResult
 
         Example
         -------
@@ -627,7 +664,7 @@ class Client(collections.abc.Mapping):
         items = self.backend.find_regex(kwargs, flags=flags)
         return self._get_search_results(items)
 
-    def export(self, path=sys.stdout, sep='\t', attrs=None):
+    def export(self, path=sys.stdout, sep='\t', attrs: Optional[list[str]] = None):
         """
         Export the contents of the database into a text file.
 
@@ -645,6 +682,10 @@ class Client(collections.abc.Mapping):
         devs = self.all_items
         logger.info('Creating file at %s ...', path)
         # Load item information
+        if attrs is None:
+            # TODO: decide how to handle None case, currently no-op
+            attrs = []
+
         with path as f:
             for dev in devs:
                 try:
@@ -655,7 +696,7 @@ class Client(collections.abc.Mapping):
                     logger.error("HappiItem %s was missing attribute %s",
                                  dev.name, e)
 
-    def remove_item(self, item):
+    def remove_item(self, item) -> None:
         """
         Remove an item from the database.
 
@@ -674,7 +715,7 @@ class Client(collections.abc.Mapping):
         _id = getattr(item, self._id_key)
         self.backend.delete(_id)
 
-    def _validate_item(self, item):
+    def _validate_item(self, item) -> None:
         """Validate that an item has all of the mandatory information."""
         logger.debug('Validating item %r ...', item)
 

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -533,6 +533,17 @@ def bad_db(tmp_path):
         "name": "tst_missing_mandatory",
         "last_edit": "Thu Apr 12 14:40:08 2018",
         "type": "OphydItem"
+    },
+    "tst_bad_container": {
+        "_id": "tst_bad_container",
+        "active": true,
+        "args": ["{{active}}"],
+        "creation": "Mon Jun 2 09:46:00 2025",
+        "device_class": "types.SimpleNamespace",
+        "kwargs": {"creation": "{{creation}}"},
+        "name": "tst_bad_container",
+        "last_edit": "Mon Jun 2 14:40:08 2025",
+        "type": "NotnAnItem"
     }
 }
 """)
@@ -548,6 +559,12 @@ backend=json
 path={bad_db}
 """)
     return str(happi_cfg_path.absolute())
+
+
+@pytest.fixture(scope='function')
+def bad_entry_client(bad_happi_cfg: str):
+    """ misconfigured database """
+    return happi.client.Client.from_config(cfg=bad_happi_cfg)
 
 
 @pytest.fixture(scope='function')

--- a/happi/tests/test_audit.py
+++ b/happi/tests/test_audit.py
@@ -3,14 +3,7 @@ import re
 import pytest
 from click.testing import CliRunner
 
-import happi
 from happi.cli import happi_cli
-
-
-@pytest.fixture(scope='function')
-def client(bad_happi_cfg: str):
-    """ misconfigured database """
-    return happi.client.Client.from_config(cfg=bad_happi_cfg)
 
 
 def number_failed_devices(output: str):
@@ -19,6 +12,9 @@ def number_failed_devices(output: str):
                     if '# devices failed' in line][0]
 
     match = re.search(r'(\d*) / (\d*)', summary_line)
+    if match is None:
+        return 0
+
     return int(match[1])
 
 

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -9,6 +9,7 @@ import pytest
 
 from happi import Client, HappiItem, OphydItem
 from happi.backends.json_db import JSONBackend
+from happi.client import InvalidResult, SearchResult
 from happi.errors import DuplicateError, EntryError, SearchError, TransferError
 
 logger = logging.getLogger(__name__)
@@ -89,6 +90,21 @@ def test_create_item(happi_client: Client, item_info: dict[str, Any]):
     # Invalid Entry
     with pytest.raises(TypeError):
         happi_client.create_item(int)
+
+
+def test_malformed_doc(bad_entry_client: Client):
+    assert isinstance(
+        bad_entry_client.search(name="tst_bad_container")[0],
+        InvalidResult
+    )
+    assert isinstance(
+        bad_entry_client.search(name="tst_extra_info")[0],
+        SearchResult
+    )
+
+    assert len(dict(bad_entry_client)) == 7
+    items = bad_entry_client.all_items
+    assert len(items) == 6  # only valid items returned
 
 
 def test_all_items(happi_client: Client, item: OphydItem):
@@ -353,6 +369,7 @@ def test_searchresults(client_with_three_valves: Client):
     assert valve1['name'] == 'valve1'
     assert valve1['type'] == 'OphydItem'
     assert valve1['z'] == 300
+    assert isinstance(valve1, SearchResult)
     assert isinstance(valve1.get(), types.SimpleNamespace)
 
 

--- a/happi/tests/test_client.py
+++ b/happi/tests/test_client.py
@@ -185,6 +185,7 @@ def test_search(
     res = happi_client.search(name=item_info['name'])
     # Single search return
     assert len(res) == 1
+    assert isinstance(res[0], SearchResult)
     loaded_item = res[0].item
     assert loaded_item.prefix == item_info['prefix']
     assert loaded_item.name == item_info['name']
@@ -192,6 +193,7 @@ def test_search(
     assert not happi_client.search(name='not')
     # Returned as dict
     res = happi_client.search(**item_info)
+    assert isinstance(res[0], SearchResult)
     loaded_item = res[0].item
     assert loaded_item['prefix'] == item_info['prefix']
     assert loaded_item['name'] == item_info['name']
@@ -340,6 +342,7 @@ def test_find_cfg(happi_cfg: str):
 def test_from_cfg(happi_cfg: str):
     # happi_cfg modifies environment variables to make config discoverable
     client = Client.from_config()
+    assert isinstance(client, Client)
     # Internal db path should be constructed relative to the happi cfg dir
     expected_db = os.path.abspath(os.path.join(os.path.dirname(happi_cfg), 'db.json'))
     print(happi_cfg)
@@ -350,6 +353,7 @@ def test_from_cfg(happi_cfg: str):
 def test_from_cfg_abs(happi_cfg_abs: str):
     # happi_cfg modifies environment variables to make config discoverable
     client = Client.from_config()
+    assert isinstance(client, Client)
     assert isinstance(client.backend, JSONBackend)
     # Ensure the json backend is using the db that we gave an absolute path to.
     assert client.backend.path == '/var/run/db.json'


### PR DESCRIPTION
## Description
Creates an InvalidResult that may be returned if a container is malformed.  Exceptions are still raised if keys do not exist.  This does change the behavior of a few methods, which used to simply skip results that couldn't be created.

This could be considered an API break.

Fixes a variety of type hinting errors along the way

## Motivation and Context
#299 

Also I wanted to test pcds-6.0.1 development

## How Has This Been Tested?
Mostly through test suite

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
