### PR TITLE
BUG: properly handle InvalidResult in cli search method

### DIFF
--- a/docs/source/upcoming_release_notes/366-bug_cli_invalid_entry.rst
+++ b/docs/source/upcoming_release_notes/366-bug_cli_invalid_entry.rst
@@ -1,0 +1,22 @@
+366 bug_cli_invalid_entry
+#########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Handle invalid entries gathered in cli search method.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/366-bug_cli_invalid_entry.rst
+++ b/docs/source/upcoming_release_notes/366-bug_cli_invalid_entry.rst
@@ -12,10 +12,11 @@ Features
 Bugfixes
 --------
 - Handle invalid entries gathered in cli search method.
+- Filter for SearchResults in `HappiViewMixin`.
 
 Maintenance
 -----------
-- N/A
+- Touch up some type hints in the qt model file.
 
 Contributors
 ------------

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -27,6 +27,7 @@ import platformdirs
 import prettytable
 
 import happi
+from happi.client import InvalidResult, SearchResult
 from happi.errors import SearchError
 
 from .audit import audit as run_audit
@@ -127,11 +128,15 @@ def search(
         json.dump([dict(res.item) for res in final_results], indent=2,
                   fp=sys.stdout)
     elif names:
-        out = " ".join([res.item.name for res in final_results])
+        out = " ".join([res.item.name for res in final_results
+                        if isinstance(res, SearchResult)])
         click.echo(out)
     else:
         for res in final_results:
-            res.item.show_info()
+            if isinstance(res, SearchResult):
+                res.item.show_info()
+            elif isinstance(res, InvalidResult):
+                click.secho(f"Found an invalid entry: {res}", fg="red")
 
     return final_results
 

--- a/happi/cli.py
+++ b/happi/cli.py
@@ -27,7 +27,7 @@ import platformdirs
 import prettytable
 
 import happi
-from happi.client import InvalidResult, SearchResult
+from happi.client import GenericResult, InvalidResult, SearchResult
 from happi.errors import SearchError
 
 from .audit import audit as run_audit
@@ -145,7 +145,7 @@ def search_parser(
     client: happi.Client,
     use_glob: bool,
     search_criteria: Iterable[str],
-) -> list[happi.SearchResult]:
+) -> list[GenericResult]:
     """
     Parse the user's search criteria and return the search results.
 

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -51,7 +51,7 @@ class HappiViewMixin:
         return itm
 
 
-class HappiDeviceListView(QtWidgets.QListView, HappiViewMixin):
+class HappiDeviceListView(HappiViewMixin, QtWidgets.QListView):
     """
     QListView which displays Happi entries.
 
@@ -72,13 +72,13 @@ class HappiDeviceListView(QtWidgets.QListView, HappiViewMixin):
         **kwargs
     ):
         super().__init__(parent=parent, client=client, **kwargs)
-        self.model = QtGui.QStandardItemModel()
-        self.model.setHorizontalHeaderLabels(["Devices"])
+        self._model = QtGui.QStandardItemModel()
+        self._model.setHorizontalHeaderLabels(["Devices"])
 
         self.proxy_model = QtCore.QSortFilterProxyModel()
         self.proxy_model.setFilterKeyColumn(-1)
         self.proxy_model.setDynamicSortFilter(True)
-        self.proxy_model.setSourceModel(self.model)
+        self.proxy_model.setSourceModel(self._model)
         self.setModel(self.proxy_model)
 
     def search(self, *args, **kwargs):
@@ -98,15 +98,15 @@ class HappiDeviceListView(QtWidgets.QListView, HappiViewMixin):
             return
         items = [self.create_item(entry.item) for entry in self.entries()]
 
-        self.model.clear()
+        self._model.clear()
 
         for row, itm in enumerate(items):
-            self.model.setItem(row, itm)
-        self.proxy_model.setSourceModel(self.model)
+            self._model.setItem(row, itm)
+        self.proxy_model.setSourceModel(self._model)
         self.proxy_model.sort(0, QtCore.Qt.AscendingOrder)
 
 
-class HappiDeviceTreeView(QtWidgets.QTreeView, HappiViewMixin):
+class HappiDeviceTreeView(HappiViewMixin, QtWidgets.QTreeView):
     """
     QListView which displays Happi entries.
 

--- a/happi/qt/model.py
+++ b/happi/qt/model.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from qtpy import QtCore, QtGui, QtWidgets
 
-from ..client import Client
+from ..client import Client, SearchResult
 from ..utils import get_happi_entry_value
 
 logger = logging.getLogger(__name__)
@@ -37,8 +37,11 @@ class HappiViewMixin:
 
         args and kwargs are sent directly to the `happi.Client.search` method.
         """
+        if not isinstance(self._client, Client):
+            return
 
-        self._entries = self._client.search(*args, **kwargs)
+        self._entries = [res for res in self._client.search(*args, **kwargs)
+                         if isinstance(res, SearchResult)]
 
     @staticmethod
     def create_item(entry):


### PR DESCRIPTION
  ## Description
  Handle invalid entries gathered in cli search method, and `HappiViewMixi`

  It's possible we actually want to adjust `Client.search` to take an argument that toggles whether or not invalid entries are returned.  Other parts of our stack likely assume everything coming from .search() is valid, and the previous change breaks this assumption.

  However, this does prevent us from using that kwarg in a container, and we'd have to be very clear about that documentation.  I've sort of painted myself into a corner here.  I think I'll opt for not changing the behavior of `Client.search` for now.  If we run into significantly more issues or get reports of this behavior breaking things, I'll recosnider.
  
  ## Motivation and Context
  Previously searching for this would error our due to the new InvalidEntry.  This would prevent the display of any other valid entries.

There are some other errors that crop up from the improper handling of malformed entries in cli commands (delete, edit, etc), but those existed prior to InvalidResult and likely deserve more scrutiny than I was hoping to devote to this small bug
  
  ## How Has This Been Tested?
  Interactively
  
  ## Where Has This Been Documented?
  This PR  (please ignore the unrelated spam at the beginning, I think that's a me problem)
  
  Before:
  <img width="844" alt="image" src="https://github.com/user-attachments/assets/836269f3-659a-4b5f-a8ec-bce54a4b02b1" />
  
  After:
  <img width="857" alt="image" src="https://github.com/user-attachments/assets/5a41981d-3d59-409e-8f1e-6d819ca7fe2f" />
  
  
  ## Pre-merge checklist
  - [x] Code works interactively
  - [x] Code contains descriptive docstrings, including context and API
  - [x] New/changed functions and methods are covered in the test suite where possible
  - [x] Test suite passes locally
  - [x] Test suite passes on GitHub Actions
  - [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
  - [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
